### PR TITLE
Slice 8b: nominal-struct window routing (DeviceWindowTarget / SiteWindowTarget)

### DIFF
--- a/Pulse/PulseApp.swift
+++ b/Pulse/PulseApp.swift
@@ -168,19 +168,18 @@ struct PulseApp: App {
         }
         .menuBarExtraStyle(.window)
 
-        // Per-Site Site View. The `id: "site-view"` argument
-        // disambiguates this scene from the SSH terminal scene at the
-        // openWindow call sites: both scenes register
-        // `WindowGroup(for: Int64.self)` (since Site.ID and Device.ID
-        // both resolve to Int64 via @Model's default Identifiable
-        // conformance), and without the explicit id the routing
-        // matches by registration order, which silently mis-routes
-        // device-targeted openWindow calls into this scene. See the
-        // doc-comment on `SSHTerminalScene` for the full rationale.
-        WindowGroup("Site View", id: "site-view", for: Site.ID.self) { $siteId in
+        // Per-Site Site View, keyed on the nominal `SiteWindowTarget`
+        // value type (Slice 8b). `Site.ID` and `Device.ID` both resolve
+        // to `Int64`, so keying on the raw id let device-targeted
+        // openWindow calls mis-route here by registration order; the
+        // distinct target type makes that a compile error. The
+        // `id: "site-view"` string is retained as a state-restoration
+        // anchor. See the doc-comment on `SSHTerminalScene` for the
+        // full rationale.
+        WindowGroup("Site View", id: "site-view", for: SiteWindowTarget.self) { $target in
             if showContentView {
-                if let id = siteId {
-                    SiteView(siteId: id)
+                if let target {
+                    SiteView(siteId: target.siteID)
                         .modelContainer(modelContainer)
                 }
             }

--- a/Pulse/Views/Graph Views/DeviceView.swift
+++ b/Pulse/Views/Graph Views/DeviceView.swift
@@ -202,12 +202,13 @@ struct DeviceView: View {
             // noise. SwiftUI suppresses the right-click menu
             // entirely when the builder produces no content. Future
             // UI (Open Web UI, Copy IP, etc.) extends this block
-            // when there's an operator ask. Explicit `id:
-            // "ssh-terminal"` for the routing disambiguation; see
-            // `SSHTerminalScene` doc-comment.
+            // when there's an operator ask. The id is wrapped in
+            // `DeviceWindowTarget` so routing is by type (Slice 8b); the
+            // matching `id: "ssh-terminal"` is the restoration anchor.
+            // See `SSHTerminalScene` doc-comment.
             if let primaryIP = device.primaryIP, !primaryIP.isEmpty {
                 Button {
-                    openWindow(id: "ssh-terminal", value: device.id)
+                    openWindow(id: "ssh-terminal", value: DeviceWindowTarget(deviceID: device.id))
                 } label: {
                     Label("Open SSH Terminal", systemImage: "terminal.fill")
                 }

--- a/Pulse/Views/Graph Views/SiteGraphView.swift
+++ b/Pulse/Views/Graph Views/SiteGraphView.swift
@@ -302,12 +302,13 @@ struct SiteGraphView: View {
                         .background()
                         .onTapGesture {
                             if isInPopover {
-                                // Explicit `id: "site-view"` so this
-                                // routes to the Site View scene even
-                                // though Site.ID and Device.ID both
-                                // resolve to Int64; see SSHTerminalScene
+                                // Wrap the id in `SiteWindowTarget` so
+                                // this routes to the Site View scene by
+                                // type, not by the Int64 registration
+                                // order it once shared with the terminal
+                                // scene (Slice 8b); see SSHTerminalScene
                                 // doc-comment for the routing rationale.
-                                openWindow(id: "site-view", value: siteId)
+                                openWindow(id: "site-view", value: SiteWindowTarget(siteID: siteId))
                             }
                             selectedDevice = nil
                         }

--- a/Pulse/Views/Map Views/AnnotationView.swift
+++ b/Pulse/Views/Map Views/AnnotationView.swift
@@ -103,11 +103,12 @@ struct AnnotationView: View {
             //TODO: Add button to close sheet
             Button {
                 DispatchQueue.main.async {
-                    // Explicit `id: "site-view"` so this routes to the
-                    // Site View scene even though Site.ID and Device.ID
-                    // both resolve to Int64; see SSHTerminalScene
-                    // doc-comment for the routing rationale.
-                    openWindow(id: "site-view", value: site.id)
+                    // Wrap the id in `SiteWindowTarget` so this routes to
+                    // the Site View scene by type, not by the Int64
+                    // registration order it once shared with the terminal
+                    // scene (Slice 8b); see SSHTerminalScene doc-comment
+                    // for the routing rationale.
+                    openWindow(id: "site-view", value: SiteWindowTarget(siteID: site.id))
                 }
             } label: {
                 Label("Open Topology View", systemImage: "network")

--- a/Pulse/Views/Site View Content/DeviceRow.swift
+++ b/Pulse/Views/Site View Content/DeviceRow.swift
@@ -86,13 +86,13 @@ struct DeviceRow: View {
 
             Button(action: {
                 if let device = device.first {
-                    // Explicit `id: "ssh-terminal"` disambiguates this
-                    // call from Site View's `WindowGroup(for: Int64.self)`
-                    // — both scenes are keyed on Int64-valued ids, and
-                    // without the id this call routes by registration
-                    // order rather than by intent. See `SSHTerminalScene`
-                    // doc-comment for the full rationale.
-                    openWindow(id: "ssh-terminal", value: device.id)
+                    // Wrap the id in `DeviceWindowTarget` so this routes
+                    // to the SSH terminal scene by type, not by the
+                    // Int64 registration order it once shared with Site
+                    // View (Slice 8b). The matching `id: "ssh-terminal"`
+                    // is retained as a restoration anchor. See
+                    // `SSHTerminalScene` for the full rationale.
+                    openWindow(id: "ssh-terminal", value: DeviceWindowTarget(deviceID: device.id))
                 }
             }) {
                 Label("Open SSH Terminal", systemImage: "terminal.fill")

--- a/Pulse/Views/Terminal/SSHTerminalView.swift
+++ b/Pulse/Views/Terminal/SSHTerminalView.swift
@@ -43,12 +43,13 @@ import UIKit
 /// through their teardown paths deterministically.
 ///
 /// Single-window-per-device is enforced by SwiftUI's
-/// `WindowGroup(for: Device.ID.self)` semantics for the
+/// `WindowGroup(for: DeviceWindowTarget.self)` semantics for the
 /// device-backed path, not by this view:
-/// `openWindow(id: "ssh-terminal", value: device.id)` activates the
-/// existing window for the same `Device.ID` rather than creating a
-/// duplicate. The explicit `id:` argument is required for routing
-/// disambiguation; see `SSHTerminalScene` for the rationale.
+/// `openWindow(id: "ssh-terminal", value: DeviceWindowTarget(deviceID: device.id))`
+/// activates the existing window for the same device rather than creating
+/// a duplicate. The nominal target type makes a misroute a compile error;
+/// the explicit `id:` is retained as a restoration anchor. See
+/// `SSHTerminalScene` for the rationale.
 /// The ad-hoc path (driven from `DebugSSHWindow`)
 /// is one connection at a time per debug window because the debug
 /// window itself is a singleton scene.

--- a/Pulse/Views/Terminal/SSHTerminalWindow.swift
+++ b/Pulse/Views/Terminal/SSHTerminalWindow.swift
@@ -26,27 +26,55 @@
 import SwiftUI
 import SwiftData
 
+/// Window-routing value type for the per-device SSH terminal scene.
+///
+/// `Device.ID` and `Site.ID` both resolve to `Int64` (the default
+/// `Identifiable.ID` for the two `@Model` classes whose `id: Int64`), so
+/// a bare `WindowGroup(for: Int64.self)` cannot tell a device-targeted
+/// window open from a site-targeted one. Wrapping each id in a distinct
+/// nominal type makes the two `WindowGroup` value types unambiguous: an
+/// `openWindow` aimed at the wrong scene is a compile error, not a
+/// routing-order accident.
+///
+/// `Codable` is load-bearing. SwiftUI persists the window's value for
+/// state restoration, so the conformance must stay explicit; if it is
+/// ever dropped, restored windows silently fail to decode.
+///
+/// The targets store the model's `Int64` NetBox id directly rather than
+/// the `Identifiable` associated type: `Site` is not explicitly
+/// `Identifiable`, so `Site.ID` is not usable as a stored-property type,
+/// and the `Int64` is exactly the value the `openWindow` call sites
+/// already hold.
+struct DeviceWindowTarget: Hashable, Codable {
+    let deviceID: Int64
+}
+
+/// Window-routing value type for the per-site Site View scene. See
+/// `DeviceWindowTarget` for why the id is wrapped in a nominal type.
+struct SiteWindowTarget: Hashable, Codable {
+    let siteID: Int64
+}
+
 /// Scene wrapper for the operator-facing SSH terminal. On macOS this
-/// exposes a per-`Device.ID` `WindowGroup`; SwiftUI's per-value
-/// `WindowGroup` semantics activate an existing window when the
-/// operator triggers `openWindow(id: "ssh-terminal", value: device.id)`
+/// exposes a per-`DeviceWindowTarget` `WindowGroup`; SwiftUI's per-value
+/// `WindowGroup` semantics activate an existing window when the operator
+/// triggers `openWindow(id: "ssh-terminal", value: DeviceWindowTarget(deviceID: device.id))`
 /// for a device that already has a terminal open, which is the desired
 /// single-terminal-per-device behaviour.
 ///
-/// **Why the `id: "ssh-terminal"` argument.** `Device.ID` and `Site.ID`
+/// **Why a nominal value type (Slice 8b).** `Device.ID` and `Site.ID`
 /// both resolve to `Int64` (the default `Identifiable.ID` for the two
-/// `@Model` classes whose `id: Int64`). SwiftUI's `WindowGroup(for:)`
-/// keys on the Swift type, not the textual declaration, so two
-/// `WindowGroup(for: Int64.self)` registrations collide and
-/// `openWindow(value: device.id)` matches by registration order rather
-/// than by intent. The explicit `id:` argument disambiguates the
-/// routing per the SwiftUI contract: `openWindow(id:value:)` targets
-/// exactly the named scene regardless of value-type collisions. The
-/// Site View scene carries a matching `id: "site-view"` for the same
-/// reason; both call sites pass the matching `id:`. A future slice may
-/// wrap the two ids in distinct nominal struct types
-/// (`DeviceWindowTarget`, `SiteWindowTarget`) so the disambiguation
-/// becomes a compile error rather than a string-id discipline gate.
+/// `@Model` classes whose `id: Int64`), so two
+/// `WindowGroup(for: Int64.self)` registrations would collide and a bare
+/// `openWindow(value: someInt64)` would match by registration order
+/// rather than by intent. Slice 8a fixed the runtime routing with an
+/// explicit `id:` string per scene; Slice 8b hardens that into a
+/// compile-time guarantee by keying each scene on a distinct nominal
+/// type (`DeviceWindowTarget` here, `SiteWindowTarget` for Site View).
+/// A misrouted `openWindow` is now a type error, not a registration-order
+/// accident. The `id:` strings are retained as state-restoration anchors
+/// and as a guard against a future `Int64`-keyed scene; every call site
+/// passes the matching `id:` and wraps its id in the matching target.
 ///
 /// On iOS the same view is buildable but no scene registers it here;
 /// iOS routing from a device row to the terminal is the concern of
@@ -64,9 +92,9 @@ struct SSHTerminalScene: Scene {
     /// branches below stay focused on the modifier chain and the body
     /// itself is declared once.
     @ViewBuilder
-    private func sceneContent(for deviceID: Device.ID?) -> some View {
-        if let id = deviceID {
-            SSHTerminalView(connection: .device(id))
+    private func sceneContent(for target: DeviceWindowTarget?) -> some View {
+        if let target {
+            SSHTerminalView(connection: .device(target.deviceID))
                 .modelContainer(modelContainer)
         } else {
             // SwiftUI can instantiate the scene with a nil value
@@ -108,16 +136,16 @@ struct SSHTerminalScene: Scene {
         // The iOS scene wiring (future slice) inherits the same
         // `.toolbar` declaration on the view body and renders it via
         // the platform-default toolbar surface.
-        WindowGroup("SSH Terminal", id: "ssh-terminal", for: Device.ID.self) { $deviceID in
-            sceneContent(for: deviceID)
+        WindowGroup("SSH Terminal", id: "ssh-terminal", for: DeviceWindowTarget.self) { $target in
+            sceneContent(for: target)
         }
         .windowResizability(.contentSize)
         .windowToolbarStyle(.unified(showsTitle: true))
     }
     #else
     var body: some Scene {
-        WindowGroup("SSH Terminal", id: "ssh-terminal", for: Device.ID.self) { $deviceID in
-            sceneContent(for: deviceID)
+        WindowGroup("SSH Terminal", id: "ssh-terminal", for: DeviceWindowTarget.self) { $target in
+            sceneContent(for: target)
         }
     }
     #endif

--- a/PulseTests/SSH/SSHConnectFormTests.swift
+++ b/PulseTests/SSH/SSHConnectFormTests.swift
@@ -569,4 +569,41 @@ final class SSHConnectFormTests: XCTestCase {
     func testPrimaryActionShapeFailedIsReconnect() {
         XCTAssertEqual(SSHTerminalView.primaryActionShape(for: .failed("reason")), .reconnect)
     }
+
+    // MARK: - Window routing targets (Slice 8b)
+
+    /// `DeviceWindowTarget` must round-trip through `Codable`: SwiftUI
+    /// persists the `WindowGroup` value for state restoration, so a
+    /// silent encode/decode failure would drop restored terminal
+    /// windows. Pins the conformance the routing depends on.
+    func testDeviceWindowTargetCodableRoundTrip() throws {
+        let original = DeviceWindowTarget(deviceID: 4_815_162_342)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(DeviceWindowTarget.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.deviceID, 4_815_162_342)
+    }
+
+    /// `SiteWindowTarget` must round-trip through `Codable` for the same
+    /// state-restoration reason as `DeviceWindowTarget`.
+    func testSiteWindowTargetCodableRoundTrip() throws {
+        let original = SiteWindowTarget(siteID: 1_123_581_321)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SiteWindowTarget.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.siteID, 1_123_581_321)
+    }
+
+    /// The two targets are distinct nominal types even though both wrap
+    /// `Int64`: carrying the same raw id, they encode to different
+    /// payloads (keyed by `deviceID` vs `siteID`). That distinctness is
+    /// the structural property turning a routing mix-up into a compile
+    /// error rather than the prior `Int64` registration-order collision.
+    func testWindowTargetsAreDistinctlyKeyed() throws {
+        let deviceJSON = String(data: try JSONEncoder().encode(DeviceWindowTarget(deviceID: 7)), encoding: .utf8)
+        let siteJSON = String(data: try JSONEncoder().encode(SiteWindowTarget(siteID: 7)), encoding: .utf8)
+        XCTAssertEqual(deviceJSON, "{\"deviceID\":7}")
+        XCTAssertEqual(siteJSON, "{\"siteID\":7}")
+        XCTAssertNotEqual(deviceJSON, siteJSON)
+    }
 }

--- a/docs/architecture/0001-ssh-terminal-and-web-foundations.md
+++ b/docs/architecture/0001-ssh-terminal-and-web-foundations.md
@@ -169,7 +169,7 @@ protocol PulseTransport {
 
 ### 9. UI surface — two windows, one Settings pane
 
-- `WindowGroup("SSH Terminal", for: Device.ID.self)` and `WindowGroup("Device Web", for: Device.ID.self)`, mirroring the existing `WindowGroup("Site View", for: Site.ID.self)` in `PulseApp.swift`. As-built: the SSH terminal scene ships id-addressed (`WindowGroup("SSH Terminal", id: "ssh-terminal", for: Device.ID.self)` in `SSHTerminalWindow.swift`, wired via `SSHTerminalScene` in `PulseApp.swift`) to avoid the `Device.ID` / `Site.ID` collision on `Int64`. See the Slice 8a routing-disambiguation note. The "Device Web" window is the v1.5 Web companion, not built in v1.
+- `WindowGroup("SSH Terminal", for: Device.ID.self)` and `WindowGroup("Device Web", for: Device.ID.self)`, mirroring the existing `WindowGroup("Site View", for: Site.ID.self)` in `PulseApp.swift`. As-built: the SSH terminal scene ships id-addressed (`WindowGroup("SSH Terminal", id: "ssh-terminal", for: Device.ID.self)` in `SSHTerminalWindow.swift`, wired via `SSHTerminalScene` in `PulseApp.swift`) to avoid the `Device.ID` / `Site.ID` collision on `Int64`. See the Slice 8a routing-disambiguation note (and the Slice 8b amendments summary for the nominal-struct hardening that turned the routing into a compile-time guarantee). The "Device Web" window is the v1.5 Web companion, not built in v1.
 - Entry points: `DeviceRow.contextMenu` and `DeviceView` popover, disabled when `device.primaryIP == nil`.
 - Settings → SSH:
   - **Credentials** — CRUD, SE-backed generation (default), PEM import (legacy, second screen).
@@ -422,7 +422,25 @@ grep -rn 'openWindow.*site\.id\|openWindow.*siteId' Pulse | grep -v 'id: "site-v
 
 Both must return empty (modulo doc-comment text).
 
-**Slice 8b: nominal-struct wrapper for window routing.** The right structural follow-up: wrap `Device.ID` and `Site.ID` in distinct nominal struct types (`DeviceWindowTarget { let id: Device.ID }`, `SiteWindowTarget { let id: Site.ID }`) so the WindowGroup value type is unambiguous and a future `WindowGroup(for: Int64.self)` addition becomes a compile error rather than a silent mis-route. Cost: ~5 call-site updates, 2 small struct types, one-time state-restoration reset (the WindowGroup value type changes; SwiftUI's restoration storage from the prior build no longer decodes). Benefit: collision becomes a compile error rather than a discipline gate. Deferred to a follow-up slice; the symmetric `id:` fix in Slice 8a is sufficient for today's bug and for ordering changes in `PulseApp.body`.
+## Slice 8b amendments summary
+
+Slice 8b closes the structural follow-up reserved by Slice 8a. `Device.ID` and `Site.ID` both resolve to `Int64`, so the two id-addressed `WindowGroup`s were distinguished only by their `id:` strings: a runtime discipline a future scene could silently break. This slice keys each scene on a distinct nominal value type so a misroute is a compile error. It hardens working code; Slice 8a already removed the live mis-route, so there is no behavioural bug here to fix. Three structural notes worth recording so future maintainers do not re-derive the trade-offs:
+
+- **§9 nominal window-routing value types.** `DeviceWindowTarget { let deviceID: Device.ID }` and `SiteWindowTarget { let siteID: Site.ID }` (both `Hashable & Codable`) replace the raw `Int64` `WindowGroup(for:)` value types. `WindowGroup(for:)` requires `Hashable & Codable`, which the structs satisfy exactly as `Int64` did; the win is that `openWindow(value: someDeviceTarget)` against the Site View scene no longer type-checks. Both structs live in `SSHTerminalWindow.swift` rather than their own files: they are routing envelopes for the app's two id-addressed scenes, not domain types, and co-locating avoids two new `.pbxproj` registrations for ten lines of code. *Alternative considered:* keep the Slice 8a `id:`-string discipline. Rejected because it is a review-time gate, not a compiler-enforced one; the nominal types make the next scene addition fail loudly at build time.
+- **§9 `id:` strings retained.** The `id: "ssh-terminal"` / `id: "site-view"` arguments stay even though the distinct value types now carry the routing guarantee. They remain the SwiftUI state-restoration identity and a second line of defence against a future `Int64`-keyed scene. Removing them would churn restoration storage for no structural gain.
+- **One-time state-restoration reset.** Changing the `WindowGroup` value type from `Int64` to the target structs means SwiftUI's persisted window state from a prior build no longer decodes; restored terminal and Site View windows are discarded once on the first launch after the upgrade and reopen fresh thereafter. This is operator-visible, so it is also called out in the release notes, not only here. The `Codable` round-trip is pinned by `testDeviceWindowTargetCodableRoundTrip` / `testSiteWindowTargetCodableRoundTrip` in `SSHConnectFormTests` so a future change that breaks the conformance, which would silently drop every restored window, trips a test instead.
+
+Structural gates (the Slice 8a `openWindow.*device\.id` call-site greps are superseded; the value type, not the call-site id, is now the guarantee). The first grep was deliberately chosen to fire: it returns the three real registrations before this slice and empty after, where the obvious `WindowGroup(for: Int64` grep would have matched only doc comments and passed vacuously both ways.
+
+```bash
+# No scene keys a WindowGroup on the raw model id; all three key on a target struct.
+grep -rEn 'WindowGroup\(".*for: (Device|Site)\.ID\.self\) \{' Pulse --include="*.swift"                       # empty
+grep -rEn 'WindowGroup\(".*for: (DeviceWindowTarget|SiteWindowTarget)\.self\) \{' Pulse --include="*.swift"   # 3
+# No openWindow call site passes a raw id (anchored to leading whitespace so doc comments cannot false-match).
+grep -rEn '^[[:space:]]*openWindow\(.*value: (device\.id|site\.id|siteId)' Pulse --include="*.swift"           # empty
+```
+
+The §4 and §9 §-body "as-built" pointers added in the docs-currency pass reconcile here: §9 points to the Slice 8a note for the id-addressed step and to this section for the nominal-struct hardening.
 
 ## Slice 8c note — chrome trim, decomposition, click-to-update fix
 


### PR DESCRIPTION
Closes #22. Stacked on top of #14 (base is `feat/ssh-terminal-foundations`, not `main`); merge after #14.

## What and why
`Device.ID` and `Site.ID` both resolve to `Int64`, so the SSH terminal and Site View `WindowGroup`s were distinguished only by their `id:` strings (the Slice 8a fix). This keys each scene on a distinct nominal value type so a misroute is a compile error rather than a runtime registration-order accident.

**Harden, not fix.** Slice 8a already removed the live mis-route at runtime; this slice converts that discipline into a compile-time guarantee. There is no live bug being fixed here, which is why the commit is `refactor(`, not `fix(`.

## Changes
- `DeviceWindowTarget` / `SiteWindowTarget` (`Hashable & Codable`) declared in `SSHTerminalWindow.swift` (co-located to avoid new `.pbxproj` registrations; they are routing envelopes, not domain types). Both store the `Int64` NetBox id directly because `Site` is not explicitly `Identifiable`, so `Site.ID` is not usable as a stored-property type.
- Three scene registrations (`SSHTerminalWindow.swift` x2, `PulseApp.swift` Site View) and four `openWindow` call sites (`DeviceRow`, `DeviceView`, `SiteGraphView`, `AnnotationView`) migrated to the targets. The `id:` strings are retained as state-restoration anchors.
- Adjacent doc comments updated to the nominal-target shape (no stale `openWindow(value: device.id)` examples remain).
- ADR 0001: the reserved Slice 8b forward-reference becomes a full `## Slice 8b amendments summary`, and the vacuous `Int64`-literal gate is replaced with gates that fire.

## Release note (operator-visible)
Changing the `WindowGroup` value type resets SwiftUI's saved window state once: open SSH terminal and Site View windows reopen fresh on the first launch after this lands, then restore normally. (No CHANGELOG file exists in-repo; capturing here.)

## Test plan
- `xcodebuild ... -destination 'platform=macOS' build` succeeds.
- `xcodebuild test ... -only-testing:PulseTests/SSHConnectFormTests` passes, including the new `testDeviceWindowTargetCodableRoundTrip`, `testSiteWindowTargetCodableRoundTrip`, `testWindowTargetsAreDistinctlyKeyed` (the `Codable` round-trip restoration depends on), and the existing toolbar-contract tests.
- Structural gates (all clean):
  - `grep -rEn 'WindowGroup\(".*for: (Device|Site)\.ID\.self\) \{' Pulse --include="*.swift"` -> empty
  - `grep -rEn 'WindowGroup\(".*for: (DeviceWindowTarget|SiteWindowTarget)\.self\) \{' Pulse --include="*.swift"` -> 3
  - `grep -rEn '^[[:space:]]*openWindow\(.*value: (device\.id|site\.id|siteId)' Pulse --include="*.swift"` -> empty
- Manual (operator): open an SSH terminal from a device row and a Site View from the map; each opens its own window with no mis-route. Quit/relaunch confirms the one-time restoration reset then normal restore.
