### PR TITLE
Index Device.defaultCredentialID for credential-delete cleanup (scale)

### DIFF
--- a/Pulse/Models/SwiftData Models/Device.swift
+++ b/Pulse/Models/SwiftData Models/Device.swift
@@ -33,6 +33,11 @@ import SwiftUI
 
 @Model
 final class Device {
+    // Secondary index on `defaultCredentialID` so the credential-delete
+    // cleanup fetch resolves via the index rather than a full-table scan at
+    // 1M+ devices. See the `defaultCredentialID` declaration below.
+    #Index<Device>([\.defaultCredentialID])
+
     @Attribute(.unique) var id: Int64
     var created: Date?
     var display: String?
@@ -61,11 +66,10 @@ final class Device {
     // points at the operator's preferred `SSHCredential` for this device when one has
     // been chosen; nil means the connect sheet picks at runtime. See ADR 0001 §4.
 
-    // TODO: scale. SwiftData (as of macOS 26) doesn't expose a secondary index on
-    // non-unique properties. `SSHCredentialsSettings.deleteCredential` runs
-    // `FetchDescriptor<Device>(predicate: { $0.defaultCredentialID == id })` during
-    // cleanup, which is a full-table scan at 1M+ devices. Cleanup is rare so the cost
-    // is amortised. Revisit when SwiftData gains `@Attribute(.index)` or equivalent.
+    // Indexed (see `#Index` at the top of the model). The credential-delete
+    // cleanup in `SSHCredentialsSettings.deleteCredential` runs
+    // `#Predicate { $0.defaultCredentialID == id }`; the index turns that from
+    // a full-table scan into an index lookup at 1M+ devices.
     var defaultCredentialID: UUID?
     var defaultUsername: String?
     var preferredSSHPort: Int?


### PR DESCRIPTION
Closes #27. Off `feat` (sibling of #31/#32 — touches `Device.swift`, which the terminal stack doesn't). Merge after #14.

## What and why
`SSHCredentialsSettings.deleteCredential` (`SSHCredentialsSettings.swift:400-406`) already nulls `defaultCredentialID` / `defaultUsername` on the owning devices via a `FetchDescriptor<Device>(predicate: #Predicate { $0.defaultCredentialID == id })`. The "O(n)" the audit flagged is a database-engine limitation, not a code smell: with no secondary index on the non-unique `defaultCredentialID`, that equality predicate is a full-column scan, which bites at Omega's 1M+ target (an operator-triggered scan, invisible in the lab).

The prior TODO claimed SwiftData "doesn't expose a secondary index on non-unique properties" — **stale**: the `#Index` macro shipped in macOS 15 and the project targets macOS 26. This declares `#Index<Device>([\.defaultCredentialID])`.

## Change
One model edit: add the `#Index`, replace the stale TODO with the indexed-reality note. **Cleanup logic is unchanged** — behaviour-preserving; only the query's intended access path changes.

## What the green build does and does NOT prove
`xcodebuild build` (macOS) succeeds — this proves `#Index` **compiles** at the 26.0 SDK (the drift correction: the "no secondary index" premise was false). It does **not** prove the scan is gone. That is an assumption about the SQLite query planner, not a measurement of it, and this is a scale fix whose entire justification is 1M+ behaviour. Treating "it compiles" as done would be scaling-by-assumption.

## Required before merge (load-bearing gates)

1. **Scale measurement — the deciding gate.** Demonstrate the index actually eliminates the scan, at volume. Either:
   - run with `-com.apple.CoreData.SQLDebug 1`, delete a credential, and confirm the cleanup `SELECT ... WHERE ZDEFAULTCREDENTIALID = ?` resolves via the index (`SEARCH ... USING INDEX`) rather than `SCAN`; or
   - seed ~10k then ~100k devices in a test store, delete a credential, and confirm cleanup time stays roughly flat as N grows (not linear).

   Until one of these passes, #27 is an *assumed* fix to a *measured* problem. This gate, not the build, decides whether #27 did its job.

2. **Store migration — on-device.** Adding an index is a schema change; the app builds its `ModelContainer` with automatic (lightweight) migration and `fatalError`s on failure (`PulseApp.swift:114`). Launch on a Mac with a **pre-existing** Pulse store and confirm: (a) the app launches (no migration `fatalError`), and (b) a credential delete still nulls both default fields on the affected devices (the symmetry contract at ADR `:364`, unchanged here).

No new unit test: the cleanup logic and the both-fields contract are unchanged, and the thing that matters (index consulted at volume) is the measurement gate above, not unit-observable.
