### PR TITLE
feat(web): Device Web window with self-signed TLS trust (Slice W2b)

### DIFF
--- a/Pulse.xcodeproj/project.pbxproj
+++ b/Pulse.xcodeproj/project.pbxproj
@@ -142,6 +142,11 @@
 		C96191A22ACA5721000198DB /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96191A12ACA5721000198DB /* Device.swift */; };
 		B17E050100000000000000B1 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050100000000000000A1 /* Service.swift */; };
 		B17E050200000000000000B1 /* WebHostTrust.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050200000000000000A1 /* WebHostTrust.swift */; };
+		B17E050300000000000000B1 /* WebAudit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050300000000000000A1 /* WebAudit.swift */; };
+		B17E050300000000000000B2 /* DeviceWebNavigationDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050300000000000000A2 /* DeviceWebNavigationDecider.swift */; };
+		B17E050300000000000000B3 /* DeviceWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050300000000000000A3 /* DeviceWebView.swift */; };
+		B17E050300000000000000B4 /* DeviceWebWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050300000000000000A4 /* DeviceWebWindow.swift */; };
+		B17E050300000000000000B5 /* DeviceWebTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050300000000000000A5 /* DeviceWebTests.swift */; };
 		B17E050200000000000000B2 /* WebHostTrustStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050200000000000000A2 /* WebHostTrustStore.swift */; };
 		B17E050200000000000000B3 /* TLSCertificateInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050200000000000000A3 /* TLSCertificateInspector.swift */; };
 		B17E050200000000000000B4 /* WebServiceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17E050200000000000000A4 /* WebServiceResolver.swift */; };
@@ -349,6 +354,11 @@
 		C96191A12ACA5721000198DB /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		B17E050100000000000000A1 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		B17E050200000000000000A1 /* WebHostTrust.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebHostTrust.swift; sourceTree = "<group>"; };
+		B17E050300000000000000A1 /* WebAudit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAudit.swift; sourceTree = "<group>"; };
+		B17E050300000000000000A2 /* DeviceWebNavigationDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWebNavigationDecider.swift; sourceTree = "<group>"; };
+		B17E050300000000000000A3 /* DeviceWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWebView.swift; sourceTree = "<group>"; };
+		B17E050300000000000000A4 /* DeviceWebWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWebWindow.swift; sourceTree = "<group>"; };
+		B17E050300000000000000A5 /* DeviceWebTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceWebTests.swift; sourceTree = "<group>"; };
 		B17E050200000000000000A2 /* WebHostTrustStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebHostTrustStore.swift; sourceTree = "<group>"; };
 		B17E050200000000000000A3 /* TLSCertificateInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLSCertificateInspector.swift; sourceTree = "<group>"; };
 		B17E050200000000000000A4 /* WebServiceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServiceResolver.swift; sourceTree = "<group>"; };
@@ -657,6 +667,10 @@
 				B17E050200000000000000A3 /* TLSCertificateInspector.swift */,
 				B17E050200000000000000A4 /* WebServiceResolver.swift */,
 				B17E050200000000000000A5 /* TLSTrustCoordinator.swift */,
+				B17E050300000000000000A1 /* WebAudit.swift */,
+				B17E050300000000000000A2 /* DeviceWebNavigationDecider.swift */,
+				B17E050300000000000000A3 /* DeviceWebView.swift */,
+				B17E050300000000000000A4 /* DeviceWebWindow.swift */,
 			);
 			path = Web;
 			sourceTree = "<group>";
@@ -666,6 +680,7 @@
 			children = (
 				B17E050200000000000000A6 /* WebTrustFoundationTests.swift */,
 				B17E050200000000000000A7 /* TLSTrustCoordinatorTests.swift */,
+				B17E050300000000000000A5 /* DeviceWebTests.swift */,
 			);
 			path = Web;
 			sourceTree = "<group>";
@@ -1220,6 +1235,10 @@
 				C96191A22ACA5721000198DB /* Device.swift in Sources */,
 				B17E050100000000000000B1 /* Service.swift in Sources */,
 				B17E050200000000000000B1 /* WebHostTrust.swift in Sources */,
+				B17E050300000000000000B1 /* WebAudit.swift in Sources */,
+				B17E050300000000000000B2 /* DeviceWebNavigationDecider.swift in Sources */,
+				B17E050300000000000000B3 /* DeviceWebView.swift in Sources */,
+				B17E050300000000000000B4 /* DeviceWebWindow.swift in Sources */,
 				B17E050200000000000000B2 /* WebHostTrustStore.swift in Sources */,
 				B17E050200000000000000B3 /* TLSCertificateInspector.swift in Sources */,
 				B17E050200000000000000B4 /* WebServiceResolver.swift in Sources */,
@@ -1245,6 +1264,7 @@
 				B17E050100000000000000B2 /* ServicePropertiesDecodingTests.swift in Sources */,
 				B17E050200000000000000B6 /* WebTrustFoundationTests.swift in Sources */,
 				B17E050200000000000000B7 /* TLSTrustCoordinatorTests.swift in Sources */,
+				B17E050300000000000000B5 /* DeviceWebTests.swift in Sources */,
 				A11CAFE0000000000000B004 /* SSHCertificateManagerTests.swift in Sources */,
 				A11CAFE0000000000000B005 /* SSHHostKeyDelegateTests.swift in Sources */,
 				A11CAFE0000000000000B006 /* SecureEnclaveKeyManagerTests.swift in Sources */,

--- a/Pulse/Info.plist
+++ b/Pulse/Info.plist
@@ -28,6 +28,17 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<!--
+	  Local Network privacy (macOS 15+). The Device Web companion and the SSH
+	  terminal connect to appliances on the operator's local network by private
+	  IP; macOS gates those connections behind a Local Network permission and
+	  fails them with NSURLErrorCannotConnectToHost (-1004) until the operator
+	  grants access. This usage string is what macOS shows in that prompt.
+	  NetBox / Zabbix over a routed hostname do not trip this gate; a WKWebView
+	  reaching a local appliance does.
+	-->
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Pulse connects to devices on your local network to open their web and terminal management interfaces.</string>
 	<key>UIBackgroundModes</key>
 	<array/>
 </dict>

--- a/Pulse/PulseApp.swift
+++ b/Pulse/PulseApp.swift
@@ -218,6 +218,9 @@ struct PulseApp: App {
         // `SSHTerminalScene` for the wrapping rationale.
         SSHTerminalScene(modelContainer: modelContainer)
 
+        // Operator-facing Device Web window, routed per `Device.ID`.
+        DeviceWebScene(modelContainer: modelContainer)
+
         #if DEBUG
         WindowGroup("Debug SSH", id: DebugSSHWindow.windowID) {
             DebugSSHWindow()

--- a/Pulse/Views/Graph Views/DeviceView.swift
+++ b/Pulse/Views/Graph Views/DeviceView.swift
@@ -212,6 +212,16 @@ struct DeviceView: View {
                     Label("Open SSH Terminal", systemImage: "terminal.fill")
                 }
             }
+
+            // Surface the Device Web window only when NetBox declares a
+            // web-serving service (WebServiceResolver is the source-of-truth rule).
+            if WebServiceResolver.primaryTarget(for: device) != nil {
+                Button {
+                    openWindow(id: "device-web", value: device.id)
+                } label: {
+                    Label("Open Web UI", systemImage: "globe")
+                }
+            }
         }
     }
     

--- a/Pulse/Views/Site View Content/DeviceRow.swift
+++ b/Pulse/Views/Site View Content/DeviceRow.swift
@@ -102,6 +102,19 @@ struct DeviceRow: View {
             // host to connect to.
             .disabled(device.first?.primaryIP?.isEmpty != false)
 
+            Button(action: {
+                if let device = device.first {
+                    // Routed to the Device Web scene by `id: "device-web"`,
+                    // same disambiguation rationale as the SSH terminal above.
+                    openWindow(id: "device-web", value: device.id)
+                }
+            }) {
+                Label("Open Web UI", systemImage: "globe")
+            }
+            // Disabled unless NetBox declares a web-serving (HTTP/HTTPS) service
+            // for this device. WebServiceResolver is the source-of-truth rule.
+            .disabled(device.first.flatMap { WebServiceResolver.primaryTarget(for: $0) } == nil)
+
             Button(role: .destructive, action: {
                 if let device = device.first {
                     let deviceId = device.id

--- a/Pulse/Web/DeviceWebNavigationDecider.swift
+++ b/Pulse/Web/DeviceWebNavigationDecider.swift
@@ -1,0 +1,214 @@
+//
+//  DeviceWebNavigationDecider.swift
+//  Pulse
+//
+//  Copyright © 2025-present Omega Networks Limited.
+//
+//  Pulse
+//  The Platform for Unified Leadership in Smart Environments.
+//
+//  This program is distributed to enable communities to build and maintain their own
+//  digital sovereignty through local control of critical infrastructure data.
+//
+//  By open sourcing Pulse, we create a circular economy where contributors can both build
+//  upon and benefit from the platform, ensuring that value flows back to communities rather
+//  than being extracted by external entities. This aligns with our commitment to intergenerational
+//  prosperity through collaborative stewardship of public infrastructure.
+//
+//  This program is free software: communities can deploy it for sovereignty, academia can
+//  extend it for research, and industry can integrate it for resilience, all under the terms
+//  of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Security
+import WebKit
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+// MARK: - Web origin
+
+/// A scheme + host + port tuple used to keep in-app navigation contained to the
+/// device the window was opened for. Pure and unit-testable.
+struct WebOrigin: Equatable, Sendable {
+    let scheme: String
+    let host: String
+    let port: Int
+
+    init(scheme: String, host: String, port: Int) {
+        self.scheme = scheme.lowercased()
+        self.host = host.lowercased()
+        self.port = port
+    }
+
+    /// Derives an origin from a URL, defaulting the port from the scheme when the
+    /// URL omits it. Returns nil for a URL without a scheme or host.
+    init?(url: URL) {
+        guard let scheme = url.scheme?.lowercased(), let host = url.host()?.lowercased() else {
+            return nil
+        }
+        self.init(scheme: scheme, host: host, port: url.port ?? (scheme == "https" ? 443 : 80))
+    }
+
+    /// Same-origin per scheme, host, and port. In-app navigation to a same-origin
+    /// URL is allowed; anything else is routed to the system browser.
+    func allows(_ url: URL) -> Bool {
+        guard let other = WebOrigin(url: url) else { return false }
+        return other == self
+    }
+}
+
+// MARK: - Device web navigation decider
+
+/// Drives the two policy decisions for a device's web window: keeping navigation
+/// contained to the device's origin, and accepting an otherwise-untrusted TLS
+/// certificate through the W2a trust foundation.
+///
+/// A `final class` (not a struct) because `WebPage.NavigationDeciding`'s methods
+/// are `@MainActor mutating`: a class satisfies the `mutating` requirement
+/// trivially and lets the decider hold references to the MainActor trust
+/// coordinator and the trust store for the window's lifetime.
+@MainActor
+final class DeviceWebNavigationDecider: WebPage.NavigationDeciding {
+
+    let origin: WebOrigin
+    private let coordinator: TLSTrustCoordinator
+    private let store: any WebHostTrustStore
+
+    init(origin: WebOrigin, coordinator: TLSTrustCoordinator, store: any WebHostTrustStore) {
+        self.origin = origin
+        self.coordinator = coordinator
+        self.store = store
+    }
+
+    // MARK: Origin containment
+
+    func decidePolicy(
+        for action: WebPage.NavigationAction,
+        preferences: inout WebPage.NavigationPreferences
+    ) async -> WKNavigationActionPolicy {
+        guard let url = action.request.url else { return .cancel }
+        if origin.allows(url) {
+            return .allow
+        }
+        // Foreign origin: keep the in-app view pinned to this device and hand the
+        // link to the system browser rather than navigating away inside Pulse.
+        await openInSystemBrowser(url)
+        WebAudit.navigationBlocked(host: origin.host, toURL: url.absoluteString)
+        return .cancel
+    }
+
+    // MARK: Server-trust challenge
+
+    func decideAuthenticationChallengeDisposition(
+        for challenge: URLAuthenticationChallenge
+    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
+        let space = challenge.protectionSpace
+        guard space.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = space.serverTrust else {
+            // Non-server-trust challenge (basic, digest, client cert). Pulse does
+            // not collect web credentials in v1.5; let the system handle it.
+            return (.performDefaultHandling, nil)
+        }
+
+        let host = space.host
+        let port = space.port
+
+        // Standard validation first: a certificate that chains to a trusted root
+        // needs no operator prompt.
+        var trustError: CFError?
+        let systemTrusted = SecTrustEvaluateWithError(serverTrust, &trustError)
+
+        guard let (fingerprint, algorithm) = TLSCertificateInspector.leafFingerprint(of: serverTrust) else {
+            // Unreadable certificate chain: refuse rather than guess.
+            return (.cancelAuthenticationChallenge, nil)
+        }
+
+        let recorded = try? await store.trust(forHost: host, port: port)
+        let decision = WebHostTrustEvaluator.evaluate(
+            systemTrusted: systemTrusted,
+            recorded: recorded,
+            presentedFingerprint: fingerprint
+        )
+
+        switch decision {
+        case .acceptSystemTrusted:
+            WebAudit.systemTrusted(host: host, port: port)
+            return (.performDefaultHandling, nil)
+
+        case .acceptPinned:
+            try? await store.touchLastVerified(forHost: host, port: port)
+            return (.useCredential, URLCredential(trust: serverTrust))
+
+        case .promptFirstSight:
+            let outcome = await coordinator.decide(
+                host: host,
+                port: port,
+                scheme: origin.scheme,
+                reason: "self-signed or untrusted certificate",
+                presentedFingerprint: fingerprint,
+                presentedAlgorithm: algorithm
+            )
+            if case .accept = outcome {
+                try? await store.recordPinned(host: host, port: port, fingerprintSHA256: fingerprint, algorithm: algorithm)
+                WebAudit.pinned(host: host, port: port, fingerprint: fingerprint)
+                return (.useCredential, URLCredential(trust: serverTrust))
+            }
+            WebAudit.rejected(host: host, port: port, reason: Self.rejectReason(outcome))
+            return (.cancelAuthenticationChallenge, nil)
+
+        case let .promptMismatch(recordedFingerprint, recordedAlgorithm):
+            let firstSeen = try? await store.firstSeenAt(forHost: host, port: port)
+            let outcome = await coordinator.decide(
+                host: host,
+                port: port,
+                scheme: origin.scheme,
+                reason: "changed certificate",
+                presentedFingerprint: fingerprint,
+                presentedAlgorithm: algorithm,
+                recordedFingerprint: recordedFingerprint,
+                recordedAlgorithm: recordedAlgorithm,
+                recordedFirstSeenAt: firstSeen
+            )
+            switch outcome {
+            case .accept:
+                try? await store.replacePin(host: host, port: port, fingerprintSHA256: fingerprint, algorithm: algorithm)
+                WebAudit.accepted(host: host, port: port, fingerprint: fingerprint)
+                return (.useCredential, URLCredential(trust: serverTrust))
+            case .forget:
+                try? await store.forget(host: host, port: port)
+                WebAudit.forgotten(host: host, port: port)
+                return (.cancelAuthenticationChallenge, nil)
+            case let .reject(reason):
+                WebAudit.rejected(host: host, port: port, reason: reason)
+                return (.cancelAuthenticationChallenge, nil)
+            }
+
+        case let .rejectDistrusted(reason):
+            WebAudit.rejected(host: host, port: port, reason: reason)
+            return (.cancelAuthenticationChallenge, nil)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func rejectReason(_ outcome: TLSTrustDecision) -> String? {
+        if case let .reject(reason) = outcome { return reason }
+        return nil
+    }
+
+    private func openInSystemBrowser(_ url: URL) async {
+        #if os(macOS)
+        NSWorkspace.shared.open(url)
+        #else
+        await UIApplication.shared.open(url)
+        #endif
+    }
+}

--- a/Pulse/Web/DeviceWebNavigationDecider.swift
+++ b/Pulse/Web/DeviceWebNavigationDecider.swift
@@ -24,6 +24,7 @@
 //
 
 import Foundation
+import OSLog
 import Security
 import WebKit
 
@@ -81,6 +82,7 @@ final class DeviceWebNavigationDecider: WebPage.NavigationDeciding {
     let origin: WebOrigin
     private let coordinator: TLSTrustCoordinator
     private let store: any WebHostTrustStore
+    private let logger = Logger(subsystem: "pulse", category: "web.trust")
 
     init(origin: WebOrigin, coordinator: TLSTrustCoordinator, store: any WebHostTrustStore) {
         self.origin = origin
@@ -95,7 +97,9 @@ final class DeviceWebNavigationDecider: WebPage.NavigationDeciding {
         preferences: inout WebPage.NavigationPreferences
     ) async -> WKNavigationActionPolicy {
         guard let url = action.request.url else { return .cancel }
-        if origin.allows(url) {
+        let allowed = origin.allows(url)
+        logger.debug("web.nav.decide host=\(url.host() ?? "nil", privacy: .public) allowed=\(allowed)")
+        if allowed {
             return .allow
         }
         // Foreign origin: keep the in-app view pinned to this device and hand the
@@ -111,10 +115,12 @@ final class DeviceWebNavigationDecider: WebPage.NavigationDeciding {
         for challenge: URLAuthenticationChallenge
     ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
         let space = challenge.protectionSpace
+        logger.notice("web.trust.challenge host=\(space.host, privacy: .public) port=\(space.port, privacy: .public) method=\(space.authenticationMethod, privacy: .public)")
         guard space.authenticationMethod == NSURLAuthenticationMethodServerTrust,
               let serverTrust = space.serverTrust else {
             // Non-server-trust challenge (basic, digest, client cert). Pulse does
             // not collect web credentials in v1.5; let the system handle it.
+            logger.notice("web.trust.challenge.not_server_trust method=\(space.authenticationMethod, privacy: .public)")
             return (.performDefaultHandling, nil)
         }
 
@@ -128,8 +134,11 @@ final class DeviceWebNavigationDecider: WebPage.NavigationDeciding {
 
         guard let (fingerprint, algorithm) = TLSCertificateInspector.leafFingerprint(of: serverTrust) else {
             // Unreadable certificate chain: refuse rather than guess.
+            logger.error("web.trust.fingerprint_unavailable host=\(host, privacy: .public)")
             return (.cancelAuthenticationChallenge, nil)
         }
+
+        logger.notice("web.trust.evaluate host=\(host, privacy: .public) systemTrusted=\(systemTrusted) fp=\(fingerprint, privacy: .public)")
 
         let recorded = try? await store.trust(forHost: host, port: port)
         let decision = WebHostTrustEvaluator.evaluate(

--- a/Pulse/Web/DeviceWebView.swift
+++ b/Pulse/Web/DeviceWebView.swift
@@ -23,6 +23,7 @@
 //  along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
+import OSLog
 import SwiftData
 import SwiftUI
 import WebKit
@@ -96,7 +97,16 @@ struct DeviceWebView: View {
     private var content: some View {
         if let page {
             VStack(spacing: 0) {
-                WebView(page)
+                if let loadFailure {
+                    ContentUnavailableView {
+                        Label("Could not load", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(loadFailure)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    WebView(page)
+                }
                 endpointStrip
             }
         } else if devices.first == nil {
@@ -221,7 +231,10 @@ struct DeviceWebView: View {
                 loadFailure = nil
             }
         } catch {
-            loadFailure = error.localizedDescription
+            let nsError = error as NSError
+            Logger(subsystem: "pulse", category: "web.session")
+                .error("web.session.load_failed host=\(resolved.host, privacy: .public) port=\(resolved.port, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code) desc=\(nsError.localizedDescription, privacy: .public)")
+            loadFailure = "\(nsError.localizedDescription)\n\(nsError.domain) \(nsError.code)"
         }
     }
 
@@ -236,6 +249,7 @@ struct DeviceWebView: View {
     }
 
     private func reload() {
+        loadFailure = nil
         _ = page?.reload()
     }
 }

--- a/Pulse/Web/DeviceWebView.swift
+++ b/Pulse/Web/DeviceWebView.swift
@@ -89,6 +89,12 @@ struct DeviceWebView: View {
             .sheet(item: $trustCoordinator.pending) { pending in
                 TLSTrustPromptSheet(pending: pending)
             }
+            .onChange(of: trustCoordinator.acceptTick) {
+                // The operator accepted a certificate; reload so the page
+                // connects with the now-pinned cert and the error view clears.
+                loadFailure = nil
+                _ = page?.reload()
+            }
     }
 
     // MARK: - Content

--- a/Pulse/Web/DeviceWebView.swift
+++ b/Pulse/Web/DeviceWebView.swift
@@ -102,8 +102,10 @@ struct DeviceWebView: View {
                         Label("Could not load", systemImage: "exclamationmark.triangle")
                     } description: {
                         Text(loadFailure)
+                            .textSelection(.enabled)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .textSelection(.enabled)
                 } else {
                     WebView(page)
                 }
@@ -231,10 +233,19 @@ struct DeviceWebView: View {
                 loadFailure = nil
             }
         } catch {
+            // WebPage.NavigationError is an opaque wrapper (often code 0); the
+            // real cause is usually the URL-loading error it carries in
+            // NSUnderlyingError. Surface both so an operator can read and copy
+            // the actionable code (for example -1202 untrusted cert, -1022 ATS).
             let nsError = error as NSError
+            let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
             Logger(subsystem: "pulse", category: "web.session")
-                .error("web.session.load_failed host=\(resolved.host, privacy: .public) port=\(resolved.port, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code) desc=\(nsError.localizedDescription, privacy: .public)")
-            loadFailure = "\(nsError.localizedDescription)\n\(nsError.domain) \(nsError.code)"
+                .error("web.session.load_failed host=\(resolved.host, privacy: .public) port=\(resolved.port, privacy: .public) domain=\(nsError.domain, privacy: .public) code=\(nsError.code) underlying=\(underlying.map { "\($0.domain)#\($0.code)" } ?? "none", privacy: .public) desc=\(nsError.localizedDescription, privacy: .public)")
+            var message = "\(nsError.localizedDescription)\n\(nsError.domain) \(nsError.code)"
+            if let underlying {
+                message += "\nunderlying: \(underlying.domain) \(underlying.code) \(underlying.localizedDescription)"
+            }
+            loadFailure = message
         }
     }
 

--- a/Pulse/Web/DeviceWebView.swift
+++ b/Pulse/Web/DeviceWebView.swift
@@ -1,0 +1,241 @@
+//
+//  DeviceWebView.swift
+//  Pulse
+//
+//  Copyright © 2025-present Omega Networks Limited.
+//
+//  Pulse
+//  The Platform for Unified Leadership in Smart Environments.
+//
+//  This program is distributed to enable communities to build and maintain their own
+//  digital sovereignty through local control of critical infrastructure data.
+//
+//  By open sourcing Pulse, we create a circular economy where contributors can both build
+//  upon and benefit from the platform, ensuring that value flows back to communities rather
+//  than being extracted by external entities. This aligns with our commitment to intergenerational
+//  prosperity through collaborative stewardship of public infrastructure.
+//
+//  This program is free software: communities can deploy it for sovereignty, academia can
+//  extend it for research, and industry can integrate it for resilience, all under the terms
+//  of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftData
+import SwiftUI
+import WebKit
+
+// MARK: - Web load status
+
+/// Coarse load state for the toolbar, derived from the `@Observable` `WebPage`
+/// plus any thrown navigation error. Pure mapping so it is unit-testable without
+/// rendering or a live page.
+enum WebLoadStatus: Equatable {
+    case loading
+    case loaded
+    case failed(String)
+
+    static func resolve(isLoading: Bool, failure: String?) -> WebLoadStatus {
+        if let failure { return .failed(failure) }
+        return isLoading ? .loading : .loaded
+    }
+
+    var label: String {
+        switch self {
+        case .loading: return "Loading"
+        case .loaded: return "Loaded"
+        case .failed: return "Failed"
+        }
+    }
+}
+
+// MARK: - Device web view
+
+/// Operator-facing window that renders a device's web UI, mirroring
+/// `SSHTerminalView`. The web target is resolved from the device's NetBox
+/// services (`WebServiceResolver`); the page is driven by a `WebPage` whose
+/// navigation decider contains navigation to the device origin and routes the
+/// self-signed-TLS trust decision through the W2a trust coordinator.
+struct DeviceWebView: View {
+
+    let deviceID: Device.ID
+
+    @Query private var devices: [Device]
+    @Environment(\.modelContext) private var modelContext
+
+    @StateObject private var trustCoordinator = TLSTrustCoordinator()
+
+    /// `WebPage` is `@Observable`; held in `@State` and built once in `.task`.
+    @State private var page: WebPage?
+    /// Retains the decider for the page's lifetime (`WebPage` does not expose it
+    /// back to us).
+    @State private var decider: DeviceWebNavigationDecider?
+    @State private var loadFailure: String?
+
+    init(deviceID: Device.ID) {
+        self.deviceID = deviceID
+        _devices = Query(filter: #Predicate<Device> { $0.id == deviceID })
+    }
+
+    var body: some View {
+        content
+            .frame(minWidth: 720, minHeight: 480)
+            .navigationTitle(navigationTitle)
+            .toolbar { webToolbar }
+            .task { await setUp() }
+            .sheet(item: $trustCoordinator.pending) { pending in
+                TLSTrustPromptSheet(pending: pending)
+            }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if let page {
+            VStack(spacing: 0) {
+                WebView(page)
+                endpointStrip
+            }
+        } else if devices.first == nil {
+            ContentUnavailableView("Device not found", systemImage: "questionmark.circle")
+        } else if webTarget == nil {
+            ContentUnavailableView {
+                Label("No web service", systemImage: "globe.badge.chevron.backward")
+            } description: {
+                Text("This device has no HTTP or HTTPS service defined in NetBox. Define one in NetBox to open its web UI.")
+            }
+        } else {
+            ProgressView().controlSize(.large)
+        }
+    }
+
+    @ViewBuilder
+    private var endpointStrip: some View {
+        if let target = webTarget {
+            HStack {
+                Text(page?.url?.absoluteString ?? target.url.absoluteString)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .accessibilityLabel("Current address")
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var webToolbar: some ToolbarContent {
+        ToolbarItem(id: "web-back", placement: .navigation) {
+            Button {
+                goBack()
+            } label: {
+                Label("Back", systemImage: "chevron.backward")
+            }
+            .disabled(!canGoBack)
+        }
+
+        ToolbarItem(id: "web-forward", placement: .navigation) {
+            Button {
+                goForward()
+            } label: {
+                Label("Forward", systemImage: "chevron.forward")
+            }
+            .disabled(!canGoForward)
+        }
+
+        ToolbarItem(id: "web-progress", placement: .navigation) {
+            if let page {
+                if page.isLoading {
+                    ProgressView(value: page.estimatedProgress)
+                        .frame(width: 120)
+                } else {
+                    let status = WebLoadStatus.resolve(isLoading: false, failure: loadFailure)
+                    if case .failed = status {
+                        Text(status.label)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+        }
+
+        ToolbarItem(id: "web-reload", placement: .primaryAction) {
+            Button {
+                reload()
+            } label: {
+                Label("Reload", systemImage: "arrow.clockwise")
+            }
+            .disabled(page == nil)
+        }
+    }
+
+    // MARK: - Derived state
+
+    private var webTarget: WebTarget? {
+        devices.first.flatMap { WebServiceResolver.primaryTarget(for: $0) }
+    }
+
+    private var navigationTitle: String {
+        if let page, !page.title.isEmpty { return page.title }
+        return webTarget?.serviceName ?? "Device Web"
+    }
+
+    private var canGoBack: Bool {
+        !(page?.backForwardList.backList.isEmpty ?? true)
+    }
+
+    private var canGoForward: Bool {
+        !(page?.backForwardList.forwardList.isEmpty ?? true)
+    }
+
+    // MARK: - Actions
+
+    private func setUp() async {
+        guard page == nil,
+              let device = devices.first,
+              let resolved = WebServiceResolver.primaryTarget(for: device),
+              let origin = WebOrigin(url: resolved.url) else {
+            return
+        }
+
+        let store = SwiftDataWebHostTrustStore(modelContainer: modelContext.container)
+        let navigationDecider = DeviceWebNavigationDecider(origin: origin, coordinator: trustCoordinator, store: store)
+        let newPage = WebPage(navigationDecider: navigationDecider)
+
+        decider = navigationDecider
+        page = newPage
+        WebAudit.opened(host: resolved.host, port: resolved.port, service: resolved.serviceName)
+
+        // Drive the load and surface a thrown navigation error as the load
+        // failure; the toolbar progress binds to the page's observable state.
+        do {
+            for try await _ in newPage.load(URLRequest(url: resolved.url)) {
+                loadFailure = nil
+            }
+        } catch {
+            loadFailure = error.localizedDescription
+        }
+    }
+
+    private func goBack() {
+        guard let page, let item = page.backForwardList.backList.last else { return }
+        _ = page.load(item)
+    }
+
+    private func goForward() {
+        guard let page, let item = page.backForwardList.forwardList.first else { return }
+        _ = page.load(item)
+    }
+
+    private func reload() {
+        _ = page?.reload()
+    }
+}

--- a/Pulse/Web/DeviceWebWindow.swift
+++ b/Pulse/Web/DeviceWebWindow.swift
@@ -1,0 +1,67 @@
+//
+//  DeviceWebWindow.swift
+//  Pulse
+//
+//  Copyright © 2025-present Omega Networks Limited.
+//
+//  Pulse
+//  The Platform for Unified Leadership in Smart Environments.
+//
+//  This program is distributed to enable communities to build and maintain their own
+//  digital sovereignty through local control of critical infrastructure data.
+//
+//  By open sourcing Pulse, we create a circular economy where contributors can both build
+//  upon and benefit from the platform, ensuring that value flows back to communities rather
+//  than being extracted by external entities. This aligns with our commitment to intergenerational
+//  prosperity through collaborative stewardship of public infrastructure.
+//
+//  This program is free software: communities can deploy it for sovereignty, academia can
+//  extend it for research, and industry can integrate it for resilience, all under the terms
+//  of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftData
+import SwiftUI
+
+/// Operator-facing Device Web window, routed per `Device.ID`. Mirrors
+/// `SSHTerminalScene`: an explicit `id: "device-web"` disambiguates the
+/// `WindowGroup(for: Device.ID.self)` registration from the SSH terminal and
+/// Site View scenes, which also key on `Int64`-valued ids (see the Slice 8a
+/// routing-disambiguation note). It converges with the nominal window-target
+/// struct when that slice lands.
+struct DeviceWebScene: Scene {
+
+    let modelContainer: ModelContainer
+
+    @ViewBuilder
+    private func sceneContent(for deviceID: Device.ID?) -> some View {
+        if let id = deviceID {
+            DeviceWebView(deviceID: id)
+                .modelContainer(modelContainer)
+        } else {
+            // SwiftUI can instantiate the scene with a nil value during
+            // restoration. Show a placeholder rather than crashing.
+            Text("No device selected.")
+                .padding()
+        }
+    }
+
+    #if os(macOS)
+    var body: some Scene {
+        WindowGroup("Device Web", id: "device-web", for: Device.ID.self) { $deviceID in
+            sceneContent(for: deviceID)
+        }
+        .windowResizability(.contentSize)
+        .windowToolbarStyle(.unified(showsTitle: true))
+    }
+    #else
+    var body: some Scene {
+        WindowGroup("Device Web", id: "device-web", for: Device.ID.self) { $deviceID in
+            sceneContent(for: deviceID)
+        }
+    }
+    #endif
+}

--- a/Pulse/Web/TLSTrustCoordinator.swift
+++ b/Pulse/Web/TLSTrustCoordinator.swift
@@ -61,6 +61,12 @@ final class TLSTrustCoordinator: ObservableObject {
 
     @Published var pending: PendingTLSTrust?
 
+    /// Bumped each time the operator accepts a trust prompt. The view observes
+    /// this to reload the page so it connects with the now-pinned certificate:
+    /// accepting a server-trust challenge does not reliably resume the suspended
+    /// provisional navigation, so an explicit reload is the robust path.
+    @Published private(set) var acceptTick = 0
+
     private let decisionTimeout: Duration
 
     init(decisionTimeout: Duration = .seconds(90)) {
@@ -115,7 +121,12 @@ final class TLSTrustCoordinator: ObservableObject {
                     recordedFingerprint: recordedFingerprint,
                     recordedAlgorithm: recordedAlgorithm,
                     recordedFirstSeenAt: recordedFirstSeenAt,
-                    resume: { decision in box.resumeIfNeeded(with: decision) }
+                    resume: { [weak self] decision in
+                        if case .accept = decision {
+                            Task { @MainActor in self?.acceptTick += 1 }
+                        }
+                        box.resumeIfNeeded(with: decision)
+                    }
                 )
                 let requestID = request.id
                 let timeout = self.decisionTimeout

--- a/Pulse/Web/WebAudit.swift
+++ b/Pulse/Web/WebAudit.swift
@@ -1,0 +1,97 @@
+//
+//  WebAudit.swift
+//  Pulse
+//
+//  Copyright © 2025-present Omega Networks Limited.
+//
+//  Pulse
+//  The Platform for Unified Leadership in Smart Environments.
+//
+//  This program is distributed to enable communities to build and maintain their own
+//  digital sovereignty through local control of critical infrastructure data.
+//
+//  By open sourcing Pulse, we create a circular economy where contributors can both build
+//  upon and benefit from the platform, ensuring that value flows back to communities rather
+//  than being extracted by external entities. This aligns with our commitment to intergenerational
+//  prosperity through collaborative stewardship of public infrastructure.
+//
+//  This program is free software: communities can deploy it for sovereignty, academia can
+//  extend it for research, and industry can integrate it for resilience, all under the terms
+//  of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import OSLog
+
+// MARK: - WebAudit
+
+/// Typed emitter for the device-web audit surface, mirroring `CredentialAudit`:
+/// a typed `Event`, a single `emit` chokepoint, and a leading token that is the
+/// SIEM contract. Owns the `web.trust.*` and `web.session.*` namespaces. The
+/// navigation decider routes its TLS-trust decisions and origin-containment
+/// outcomes through here so every web token is defined in one greppable place.
+enum WebAudit {
+
+    enum Event: Sendable, Equatable {
+
+        // MARK: Trust (category: web.trust)
+
+        /// The certificate chained to a trusted root and loaded with no prompt.
+        case systemTrusted(host: String, port: Int)
+        /// An untrusted certificate was trusted on first sight and pinned.
+        case pinned(host: String, port: Int, fingerprint: String)
+        /// A changed certificate was accepted (re-pinned) by the operator.
+        case accepted(host: String, port: Int, fingerprint: String)
+        /// A trust prompt was rejected. `reason` distinguishes an operator
+        /// reject (nil) from `decision_timeout` / `cancelled`, or an explicit
+        /// distrust reason.
+        case rejected(host: String, port: Int, reason: String?)
+        /// An operator forgot a pin; the next connection is a fresh first sight.
+        case forgotten(host: String, port: Int)
+
+        // MARK: Session (category: web.session)
+
+        /// A device web window opened against a resolved service target.
+        case opened(host: String, port: Int, service: String)
+        /// In-app navigation to a foreign origin was blocked and handed to the
+        /// system browser.
+        case navigationBlocked(host: String, toURL: String)
+    }
+
+    private static let trustLogger = Logger(subsystem: "pulse", category: "web.trust")
+    private static let sessionLogger = Logger(subsystem: "pulse", category: "web.session")
+
+    static func emit(_ event: Event) {
+        switch event {
+        case let .systemTrusted(host, port):
+            trustLogger.notice("web.trust.system host=\(host, privacy: .public) port=\(port, privacy: .public)")
+        case let .pinned(host, port, fingerprint):
+            trustLogger.notice("web.trust.pinned host=\(host, privacy: .public) port=\(port, privacy: .public) fp=\(fingerprint, privacy: .public)")
+        case let .accepted(host, port, fingerprint):
+            trustLogger.warning("web.trust.accepted host=\(host, privacy: .public) port=\(port, privacy: .public) fp=\(fingerprint, privacy: .public)")
+        case let .rejected(host, port, reason):
+            trustLogger.warning("web.trust.rejected host=\(host, privacy: .public) port=\(port, privacy: .public) reason=\(reason ?? "operator", privacy: .public)")
+        case let .forgotten(host, port):
+            trustLogger.warning("web.trust.forgotten host=\(host, privacy: .public) port=\(port, privacy: .public)")
+        case let .opened(host, port, service):
+            sessionLogger.notice("web.session.opened host=\(host, privacy: .public) port=\(port, privacy: .public) service=\(service, privacy: .public)")
+        case let .navigationBlocked(host, toURL):
+            sessionLogger.notice("web.session.navigation_blocked host=\(host, privacy: .public) to=\(toURL, privacy: .public)")
+        }
+    }
+}
+
+// MARK: - Convenience emitters
+
+extension WebAudit {
+    static func systemTrusted(host: String, port: Int) { emit(.systemTrusted(host: host, port: port)) }
+    static func pinned(host: String, port: Int, fingerprint: String) { emit(.pinned(host: host, port: port, fingerprint: fingerprint)) }
+    static func accepted(host: String, port: Int, fingerprint: String) { emit(.accepted(host: host, port: port, fingerprint: fingerprint)) }
+    static func rejected(host: String, port: Int, reason: String?) { emit(.rejected(host: host, port: port, reason: reason)) }
+    static func forgotten(host: String, port: Int) { emit(.forgotten(host: host, port: port)) }
+    static func opened(host: String, port: Int, service: String) { emit(.opened(host: host, port: port, service: service)) }
+    static func navigationBlocked(host: String, toURL: String) { emit(.navigationBlocked(host: host, toURL: toURL)) }
+}

--- a/PulseTests/Web/DeviceWebTests.swift
+++ b/PulseTests/Web/DeviceWebTests.swift
@@ -1,0 +1,75 @@
+//
+//  DeviceWebTests.swift
+//  PulseTests
+//
+//  Copyright © 2025-present Omega Networks Limited.
+//
+//  This program is distributed to enable communities to build and maintain their own
+//  digital sovereignty through local control of critical infrastructure data.
+//
+//  By open sourcing Pulse, we create a circular economy where contributors can both build
+//  upon and benefit from the platform, ensuring that value flows back to communities rather
+//  than being extracted by external entities. This aligns with our commitment to intergenerational
+//  prosperity through collaborative stewardship of public infrastructure.
+//
+//  Under the terms of the GNU Affero General Public License version 3 as published by the
+//  Free Software Foundation, this program is free software: communities can deploy it for
+//  sovereignty, academia can extend it for research, and industry can integrate it for resilience.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import XCTest
+@testable import Pulse
+
+/// Headless coverage for the Slice W2b pure logic: origin containment and the
+/// toolbar load-status mapping. The on-device behaviour (the page rendering, the
+/// trust prompt firing, navigation actually routing to the system browser) is a
+/// manual gate, not headless.
+final class DeviceWebTests: XCTestCase {
+
+    // MARK: - WebOrigin containment
+
+    func testOriginAllowsSameSchemeHostPort() {
+        let origin = WebOrigin(scheme: "https", host: "10.0.0.1", port: 8006)
+        XCTAssertTrue(origin.allows(URL(string: "https://10.0.0.1:8006/")!))
+        XCTAssertTrue(origin.allows(URL(string: "https://10.0.0.1:8006/nodes/pve/summary?x=1")!))
+    }
+
+    func testOriginBlocksForeignOrigin() {
+        let origin = WebOrigin(scheme: "https", host: "10.0.0.1", port: 8006)
+        XCTAssertFalse(origin.allows(URL(string: "https://10.0.0.2:8006/")!), "different host")
+        XCTAssertFalse(origin.allows(URL(string: "https://10.0.0.1:443/")!), "different port")
+        XCTAssertFalse(origin.allows(URL(string: "http://10.0.0.1:8006/")!), "different scheme")
+        XCTAssertFalse(origin.allows(URL(string: "https://evil.example.com/")!), "different host entirely")
+    }
+
+    func testOriginDefaultsPortFromScheme() {
+        let origin = WebOrigin(scheme: "https", host: "host", port: 443)
+        // A URL omitting the port resolves to 443 for https, so it is same-origin.
+        XCTAssertTrue(origin.allows(URL(string: "https://host/")!))
+        XCTAssertEqual(WebOrigin(url: URL(string: "https://host/")!), origin)
+    }
+
+    func testOriginInitNilWithoutHost() {
+        XCTAssertNil(WebOrigin(url: URL(string: "about:blank")!))
+    }
+
+    // MARK: - WebLoadStatus
+
+    func testLoadStatusResolution() {
+        XCTAssertEqual(WebLoadStatus.resolve(isLoading: true, failure: nil), .loading)
+        XCTAssertEqual(WebLoadStatus.resolve(isLoading: false, failure: nil), .loaded)
+        // A recorded failure wins regardless of the loading flag.
+        XCTAssertEqual(WebLoadStatus.resolve(isLoading: true, failure: "boom"), .failed("boom"))
+        XCTAssertEqual(WebLoadStatus.resolve(isLoading: false, failure: "boom"), .failed("boom"))
+    }
+
+    func testLoadStatusLabels() {
+        XCTAssertEqual(WebLoadStatus.loading.label, "Loading")
+        XCTAssertEqual(WebLoadStatus.loaded.label, "Loaded")
+        XCTAssertEqual(WebLoadStatus.failed("x").label, "Failed")
+    }
+}

--- a/docs/architecture/0001-ssh-terminal-and-web-foundations.md
+++ b/docs/architecture/0001-ssh-terminal-and-web-foundations.md
@@ -169,8 +169,8 @@ protocol PulseTransport {
 
 ### 9. UI surface — two windows, one Settings pane
 
-- `WindowGroup("SSH Terminal", for: Device.ID.self)` and `WindowGroup("Device Web", for: Device.ID.self)`, mirroring the existing `WindowGroup("Site View", for: Site.ID.self)` in `PulseApp.swift`. As-built: the SSH terminal scene ships id-addressed (`WindowGroup("SSH Terminal", id: "ssh-terminal", for: Device.ID.self)` in `SSHTerminalWindow.swift`, wired via `SSHTerminalScene` in `PulseApp.swift`) to avoid the `Device.ID` / `Site.ID` collision on `Int64`. See the Slice 8a routing-disambiguation note. The "Device Web" window is the v1.5 Web companion, not built in v1.
-- Entry points: `DeviceRow.contextMenu` and `DeviceView` popover, disabled when `device.primaryIP == nil`.
+- `WindowGroup("SSH Terminal", for: Device.ID.self)` and `WindowGroup("Device Web", for: Device.ID.self)`, mirroring the existing `WindowGroup("Site View", for: Site.ID.self)` in `PulseApp.swift`. As-built: the SSH terminal scene ships id-addressed (`WindowGroup("SSH Terminal", id: "ssh-terminal", for: Device.ID.self)` in `SSHTerminalWindow.swift`, wired via `SSHTerminalScene` in `PulseApp.swift`) to avoid the `Device.ID` / `Site.ID` collision on `Int64`. See the Slice 8a routing-disambiguation note. As-built (Slice W2b): the Device Web window ships the same way, `WindowGroup("Device Web", id: "device-web", for: Device.ID.self)` in `DeviceWebWindow.swift` wired via `DeviceWebScene`, rendering a device's web UI with `WebView` / `WebPage`. See the Web companion Slice W2a and W2b amendments.
+- Entry points: `DeviceRow.contextMenu` and `DeviceView` popover. Open SSH Terminal is disabled when `device.primaryIP == nil`; Open Web UI is shown only when `WebServiceResolver.primaryTarget(for:)` resolves a NetBox-declared web service.
 - Settings → SSH:
   - **Credentials** — CRUD, SE-backed generation (default), PEM import (legacy, second screen).
   - **Host Trust** — browse, forget, import CA bundle, set per-site enforcement policy.
@@ -479,6 +479,22 @@ Slice W2a (`feat/web-companion-w2a-tls-trust`) builds the headless TLS-trust fou
 - **Audit and the window are deferred to W2b.** `WebAudit` (categories `web.trust` and `web.session`) and the navigation decider that emits it ship with the `WebView` window in W2b, where there is an emitter to exercise them. W2a's coordinator logs its own `web.trust.concurrent_decide` fault inline, mirroring the SSH coordinator.
 
 **Verification posture.** W2a is fully headless: `xcodebuild build` (macOS + iOS) compiles the new model, the schema, the store, the evaluator, the inspector, the resolver, the coordinator, and the sheet; `WebTrustFoundationTests` and `TLSTrustCoordinatorTests` cover the resolver rule, the evaluator branches, the certificate fingerprint against an independently-computed SHA-256, store idempotency, the coordinator timeout and resume, and the sheet default-focus. There is no on-device gate in W2a; the page-renders, prompt-fires, and navigation-contained gates belong to W2b.
+
+## Web companion Slice W2b amendments summary
+
+Slice W2b (`feat/web-companion-w2b-window`) ships the on-device Device Web window that consumes the W2a trust foundation, converting the §9 sketch into as-built. The decisions worth recording:
+
+- **The window and view mirror the SSH terminal.** `DeviceWebScene` (`WindowGroup("Device Web", id: "device-web", for: Device.ID.self)`) mirrors `SSHTerminalScene`, registered in `PulseApp.swift` after it, with the same string-`id:` routing discipline (the SSH and Site scenes also key on `Int64`; see the Slice 8a note). `DeviceWebView` mirrors `SSHTerminalView`: a `@Query` device-by-id, a `WebView(page)` driven by a `@State WebPage` built in `.task`, a toolbar bound to the page's `@Observable` `title` / `estimatedProgress` / `isLoading` / `backForwardList`, and a `WebLoadStatus` pure helper for the status label.
+
+- **The navigation decider is a `@MainActor final class`.** `WebPage.NavigationDeciding`'s methods are `@MainActor mutating`, so a class satisfies the `mutating` requirement trivially and holds references to the trust coordinator and store for the window's lifetime (no value-type `Box` was needed). `decidePolicy(for action:)` allows same-origin navigation (scheme, host, port, via the pure `WebOrigin`) and hands a foreign origin to the system browser. `decideAuthenticationChallengeDisposition` validates the system trust store first (`SecTrustEvaluateWithError`), then routes a failure through the W2a `WebHostTrustEvaluator` + `TLSTrustCoordinator` + store, returning `(.useCredential, URLCredential(trust:))` only on operator accept.
+
+- **The entry point reflects the source of truth.** Open Web UI is surfaced (in `DeviceRow` and `DeviceView`) only when `WebServiceResolver.primaryTarget(for:)` resolves a NetBox-declared web service, not merely when a primary IP exists. A device with no web service shows no affordance and a typed empty state in the window.
+
+- **`WebAudit` is wired.** The decider emits `web.trust.{system,pinned,accepted,rejected,forgotten}` and `web.session.{opened,navigation_blocked}` under the `pulse` subsystem.
+
+- **The deferred WebPage API surface was verified at build.** `WebView(page)` and the `_WebKit_SwiftUI` cross-import overlay; `WebPage.NavigationEvent` is `startedProvisionalNavigation` / `receivedServerRedirect` / `committed` / `finished` with load errors thrown from the `navigations` sequence; `WebPage.BackForwardList` exposes `backList` / `forwardList` / `currentItem` with `load(item:)` for back and forward; `URLCredential(trust:)` is the accept credential. All compiled clean on macOS and iOS.
+
+**Verification posture.** Headless: `xcodebuild build` (macOS + iOS) compiles the scene, view, and decider; `DeviceWebTests` covers `WebOrigin` containment and the `WebLoadStatus` mapping. On-device only (left for the human pass, cannot be faked headless): a real device's web UI renders; a trusted certificate loads silently while a self-signed certificate prompts, accept pins and loads, and a changed certificate re-prompts; the navigation decider keeps in-app navigation contained and routes foreign origins to the system browser; the window opens the correct device with no misroute and window-state restoration behaves (a new scene value type may reset saved state once). Operator guide: `docs/web-companion.md`.
 
 ## Forward-looking implementation discipline
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,6 +56,8 @@ Pulse includes an operator SSH terminal backed by the device's Secure Enclave. F
 
 > The SSH terminal UI ships on macOS today. The underlying engine (credentials, transport, recording) is platform-agnostic; iOS surfacing is tracked for a later release.
 
+**Opening a device's web UI.** Right-click a device and choose **Open Web UI** to render its web interface (Proxmox, OPNsense, an appliance console) inside Pulse. The option appears only when NetBox declares an HTTP or HTTPS service for the device; the scheme and port come from that NetBox service. A self-signed certificate prompts you to trust it on first sight, and the page stays contained to that device. See the [Web companion guide](web-companion.md) for the service rule and the certificate-trust prompt.
+
 ## 5. Terminal preferences
 
 A few terminal preferences (audible / visual bell, font size) are stored as app defaults; there is no dedicated settings pane yet. See [terminal preferences](credentials.md#terminal-preferences) for the keys and how to change them (`defaults write nz.net.omega.pulse ...`, or the in-window Cmd +/-/0 shortcuts on macOS and pinch-to-zoom on iOS).
@@ -80,5 +82,6 @@ A few terminal preferences (audible / visual bell, font size) are stored as app 
 
 - [README](../README.md) for installation and build setup.
 - [SSH credentials guide](credentials.md) for the credential and recording model.
+- [Web companion guide](web-companion.md) for the device web window and its certificate-trust prompt.
 - [Architecture (ADR 0001)](architecture/0001-ssh-terminal-and-web-foundations.md) for design decisions.
 - The project [Wiki](https://github.com/omega-networks/pulse/wiki) and issue tracker for anything else.

--- a/docs/web-companion.md
+++ b/docs/web-companion.md
@@ -10,6 +10,8 @@ Right-click a device (in the site list or the topology graph) and choose **Open 
 
 The **Open Web UI** option appears only when NetBox declares a web service for the device (see below). If it is absent, the device has no HTTP or HTTPS service defined in NetBox.
 
+The first time Pulse reaches a device on your local network, macOS asks whether Pulse may access local network devices. Grant it, or the page fails to load with a "could not connect" error (`NSURLErrorCannotConnectToHost`, -1004). You can change this later in **System Settings > Privacy & Security > Local Network**.
+
 ## How Pulse picks the URL: NetBox is the source of truth
 
 Pulse does not guess a device's web address. It reads the device's **NetBox Application Services** (IPAM > Services) and opens what NetBox declares:

--- a/docs/web-companion.md
+++ b/docs/web-companion.md
@@ -1,0 +1,69 @@
+# Device Web companion
+
+Operator guide to opening a device's web UI inside Pulse. For the architecture, see [ADR 0001](architecture/0001-ssh-terminal-and-web-foundations.md); the SSH terminal has its own guide in [credentials.md](credentials.md).
+
+The Web companion is a second operator window, a sibling to the SSH terminal. It renders a device's management web UI (Proxmox, OPNsense, a backup server, an appliance console) inside Pulse, so you do not leave the app to reach a device's browser interface.
+
+## Opening a device's web UI
+
+Right-click a device (in the site list or the topology graph) and choose **Open Web UI**. The window opens for that device and loads its web interface.
+
+The **Open Web UI** option appears only when NetBox declares a web service for the device (see below). If it is absent, the device has no HTTP or HTTPS service defined in NetBox.
+
+## How Pulse picks the URL: NetBox is the source of truth
+
+Pulse does not guess a device's web address. It reads the device's **NetBox Application Services** (IPAM > Services) and opens what NetBox declares:
+
+- The **scheme** comes from the service name. A TCP service whose name contains `HTTPS` opens over `https`; a name containing `HTTP` opens over `http`.
+- The **port** is the service's own declared port.
+- The **address** is the service's IP, with any CIDR mask stripped.
+
+So a service named `HTTPS` on port `8006` opens `https://<device-ip>:8006/`. If a device has several web services, Pulse prefers `https` over `http`, then the lowest port.
+
+If a device's web UI does not open, the fix is in NetBox: define an `HTTP` or `HTTPS` service on the device with the right port. Pulse surfaces exactly what the source of truth says.
+
+## The certificate trust prompt
+
+Many appliances serve their web UI over a self-signed or otherwise untrusted certificate. Pulse handles this with a per-host, operator-acknowledged trust decision. It never disables certificate checking globally.
+
+- **Trusted certificates load silently.** If the device's certificate chains to a trusted authority (a public or corporate CA your Mac already trusts), the page loads with no prompt.
+- **An untrusted certificate prompts you on first sight.** You see the host, the reason it is untrusted, and the certificate's SHA-256 fingerprint. Choose **Trust** to proceed (Pulse pins that certificate for this host) or **Cancel** to abort. The prompt focuses **Cancel** by default, so a stray Return key never extends trust.
+- **A changed certificate prompts a mismatch.** If a host you previously trusted later presents a different certificate, Pulse shows the stored and presented fingerprints side by side and when you first trusted it. Choose **Accept** (a legitimate rotation, re-pins), **Reject** (abort, keep the old pin), or **Forget** (drop the pin; the next connection is a fresh first sight).
+- **The prompt times out after 90 seconds.** If you do not decide, Pulse rejects the connection. This matches the SSH host-key prompt.
+
+Accepting a certificate means: for this host and port, Pulse will load that exact certificate silently from now on, and will prompt you again only if it changes.
+
+## Navigation stays on the device
+
+In-app navigation is contained to the device you opened. Links to the same host, port, and scheme load in the window. A link to any other origin is handed to your system browser instead of navigating away inside Pulse, so the window always shows the device you opened. The current address is shown beneath the page.
+
+## Where trust is stored
+
+TLS trust is stored on-device in Pulse's local database, keyed by host and port, separate from SSH host-key trust. Forgetting a device's TLS trust does not touch its SSH host-key trust, and vice versa. As with the rest of Pulse, nothing syncs to iCloud.
+
+## Audit
+
+Trust and session events are logged under the `pulse` subsystem, categories `web.trust` and `web.session`:
+
+```bash
+log show --predicate 'subsystem == "pulse" AND category BEGINSWITH "web"' --last 1h
+```
+
+Events include `web.trust.system` (loaded a trusted certificate), `web.trust.pinned` (trusted on first sight), `web.trust.accepted` (accepted a rotation), `web.trust.rejected` (with a reason such as `decision_timeout`), `web.trust.forgotten`, `web.session.opened`, and `web.session.navigation_blocked`.
+
+## Lab procedure
+
+End-to-end verification against a self-signed appliance:
+
+1. In NetBox, give a test device an `HTTPS` service on its management port (for example `8006` for Proxmox), with the device's IP.
+2. Sync Pulse so the service appears.
+3. Right-click the device and choose **Open Web UI**. The window opens and a trust prompt appears showing the certificate fingerprint.
+4. Choose **Trust**. The page loads. Confirm the address strip shows the expected `host:port`.
+5. Close and reopen the window. The page loads with no prompt (the certificate is pinned).
+6. Re-key the appliance (or point the service at a different self-signed host). Reopen. Confirm the mismatch prompt shows the stored and presented fingerprints, and that **Reject** aborts while **Accept** re-pins.
+7. Click a link to an external site. Confirm it opens in your system browser, not in the Pulse window.
+
+## Related
+
+- [ADR 0001](architecture/0001-ssh-terminal-and-web-foundations.md) for the architecture and the trust model.
+- [credentials.md](credentials.md) for the SSH terminal and its host-key trust, which the Web companion mirrors.


### PR DESCRIPTION
## What

Slice W2b of the v1.5 Web companion (#16): the **on-device Device Web window**, consuming the W2a TLS-trust foundation. It renders a device's web UI (Proxmox, OPNsense, an appliance console) inside Pulse over self-signed TLS, with per-host operator-acknowledged trust. This converts the ADR §9 sketch into as-built.

## Changes

- **`DeviceWebScene` + `DeviceWebView`** mirror `SSHTerminalScene`/`SSHTerminalView`: `WebView(page)` driven by a `@State WebPage` built in `.task`; the toolbar binds the page's `@Observable` `title` / `estimatedProgress` / `isLoading` / `backForwardList`; a pure `WebLoadStatus` helper drives the status label. Routed by `id: "device-web"` (the string-id discipline from Slice 8a).
- **`DeviceWebNavigationDecider`** (`@MainActor final class` conforming to `WebPage.NavigationDeciding`, since its methods are `@MainActor mutating`): contains in-app navigation to the device's origin via the pure `WebOrigin` (foreign origins are handed to the system browser), and routes the server-trust challenge through the W2a `WebHostTrustEvaluator` + `TLSTrustCoordinator` + store, validating the system trust store first and returning `(.useCredential, URLCredential(trust:))` only on operator accept.
- **Open Web UI** entry points in `DeviceRow` and `DeviceView`, gated on `WebServiceResolver.primaryTarget(for:)` (the NetBox source-of-truth rule), not merely on `primaryIP`.
- **`WebAudit`** emitters: `web.trust.{system,pinned,accepted,rejected,forgotten}` and `web.session.{opened,navigation_blocked}`.
- **`DeviceWebTests`**: `WebOrigin` containment and `WebLoadStatus` mapping.
- **Docs:** new `docs/web-companion.md` operator guide (incl. a Lab procedure) + a `user-guide.md` link; ADR 0001 §9 converted to as-built + a Slice W2b amendment.

## Verification posture
- macOS: `xcodebuild test` gives **TEST SUCCEEDED**, 22 Web cases pass; the full app (including the new `WebView`/`WebPage` code) compiles.
- iOS: `xcodebuild build` (generic iOS Simulator) gives **BUILD SUCCEEDED**.
- The deferred WebPage API surface was confirmed at build: `WebView(page)` + the `_WebKit_SwiftUI` overlay; `NavigationEvent` cases (errors thrown from the `navigations` sequence); `BackForwardList.backList/forwardList` + `load(item:)`; `URLCredential(trust:)`.
- **On-device only (block merge, cannot be faked headless):** a real device's web UI renders; a trusted cert loads silently while a self-signed cert prompts, accept pins and loads, a changed cert re-prompts; the navigation decider keeps in-app navigation contained and routes foreign origins to the system browser; the new window opens the correct device with no misroute and window-state restoration behaves (a new scene value type may reset saved state once). These need a build on a Mac against a real appliance and are left for the human pass.

Stacked on #35 (Slice W2a) which stacks on #34 (W1); bases retarget down to `feat` as each merges. Part of #16, tracked under #30.