### PR TITLE
chore: add GitHub Sponsors FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: Omega-Networks


### PR DESCRIPTION
Adds `.github/FUNDING.yml` (`github: Omega-Networks`) so the repo shows a Sponsor button.

`FUNDING.yml` only takes effect from the **default branch**, so this is a small standalone PR to `main` rather than riding PR #14 (which targets `main` but is still in review).

After merge, the button also needs **Settings → General → Features → Sponsorships** enabled (a web-only repo setting). For an org-wide button on every Omega-Networks repo, the same file in an org-level `.github` repo is the template-thinking alternative.