### PR TITLE
feat: NetBox changelog incremental sync (P3)

### DIFF
--- a/Pulse.xcodeproj/project.pbxproj
+++ b/Pulse.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		A11CAFE0000000000000NB1E /* NetBoxMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB0F /* NetBoxMappingTests.swift */; };
 		A11CAFE0000000000000NB53 /* NetBoxFetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB50 /* NetBoxFetching.swift */; };
 		A11CAFE0000000000000NB54 /* NetBoxSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB51 /* NetBoxSyncEngine.swift */; };
+		A11CAFE0000000000000NB81 /* NetBoxDelta.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB80 /* NetBoxDelta.swift */; };
+		A11CAFE0000000000000NB83 /* NetBoxDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB82 /* NetBoxDeltaTests.swift */; };
 		A11CAFE0000000000000NB55 /* NetBoxSyncEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB52 /* NetBoxSyncEngineTests.swift */; };
 		A11CAFE0000000000000NB61 /* NetBoxAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB60 /* NetBoxAuthorization.swift */; };
 		A11CAFE0000000000000NB63 /* NetBoxAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CAFE0000000000000NB62 /* NetBoxAuthorizationTests.swift */; };
@@ -462,6 +464,8 @@
 		A11CAFE0000000000000NB0F /* NetBoxMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxMappingTests.swift; sourceTree = "<group>"; };
 		A11CAFE0000000000000NB50 /* NetBoxFetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxFetching.swift; sourceTree = "<group>"; };
 		A11CAFE0000000000000NB51 /* NetBoxSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxSyncEngine.swift; sourceTree = "<group>"; };
+		A11CAFE0000000000000NB80 /* NetBoxDelta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxDelta.swift; sourceTree = "<group>"; };
+		A11CAFE0000000000000NB82 /* NetBoxDeltaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxDeltaTests.swift; sourceTree = "<group>"; };
 		A11CAFE0000000000000NB52 /* NetBoxSyncEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxSyncEngineTests.swift; sourceTree = "<group>"; };
 		A11CAFE0000000000000NB60 /* NetBoxAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxAuthorization.swift; sourceTree = "<group>"; };
 		A11CAFE0000000000000NB62 /* NetBoxAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetBoxAuthorizationTests.swift; sourceTree = "<group>"; };
@@ -765,6 +769,7 @@
 				A11CAFE0000000000000NB70 /* NetBoxInterfaceSchemaMigrationTests.swift */,
 				A11CAFE0000000000000NB72 /* SiteTopologyEdgesTests.swift */,
 				A11CAFE0000000000000NB52 /* NetBoxSyncEngineTests.swift */,
+				A11CAFE0000000000000NB82 /* NetBoxDeltaTests.swift */,
 				A11CAFE0000000000000NB62 /* NetBoxAuthorizationTests.swift */,
 			);
 			path = Networking;
@@ -785,6 +790,7 @@
 				A11CAFE0000000000000NB0E /* NetBoxStore.swift */,
 				A11CAFE0000000000000NB50 /* NetBoxFetching.swift */,
 				A11CAFE0000000000000NB51 /* NetBoxSyncEngine.swift */,
+				A11CAFE0000000000000NB80 /* NetBoxDelta.swift */,
 			);
 			path = NetBox;
 			sourceTree = "<group>";
@@ -1374,6 +1380,7 @@
 				A11CAFE0000000000000NB1D /* NetBoxStore.swift in Sources */,
 				A11CAFE0000000000000NB53 /* NetBoxFetching.swift in Sources */,
 				A11CAFE0000000000000NB54 /* NetBoxSyncEngine.swift in Sources */,
+				A11CAFE0000000000000NB81 /* NetBoxDelta.swift in Sources */,
 				A11CAFE0000000000000NB61 /* NetBoxAuthorization.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1393,6 +1400,7 @@
 				A11CAFE0000000000000NB71 /* NetBoxInterfaceSchemaMigrationTests.swift in Sources */,
 				A11CAFE0000000000000NB73 /* SiteTopologyEdgesTests.swift in Sources */,
 				A11CAFE0000000000000NB55 /* NetBoxSyncEngineTests.swift in Sources */,
+				A11CAFE0000000000000NB83 /* NetBoxDeltaTests.swift in Sources */,
 				A11CAFE0000000000000NB63 /* NetBoxAuthorizationTests.swift in Sources */,
 				B17E050200000000000000B6 /* WebTrustFoundationTests.swift in Sources */,
 				B17E050200000000000000B7 /* TLSTrustCoordinatorTests.swift in Sources */,

--- a/Pulse/Models/SwiftData Models/SyncProvider.swift
+++ b/Pulse/Models/SwiftData Models/SyncProvider.swift
@@ -30,12 +30,28 @@ import SwiftData
 final class SyncProvider {
     var lastNetBoxUpdate: Date?
     var lastZabbixUpdate: Date?
-    
+
     var userNotifiedNetBox: Bool = false
     var userNotifiedZabbix: Bool = false
-    
+
+    /// Latest fully-applied `/api/core/object-changes/` id. NetBox
+    /// server values only — never `Date()` / a local guess.
+    var lastObjectChangeId: Int64?
+    var lastObjectChangeTime: Date?
+    /// Client clock of the last successful full mirror. Used only for
+    /// the weekly safety interval, not as a changelog cursor.
+    var lastFullMirrorAt: Date?
+    var lastDeltaSummary: String?
+
     init(lastNetBoxUpdate: Date, lastZabbixUpdate: Date) {
         self.lastNetBoxUpdate = lastNetBoxUpdate
         self.lastZabbixUpdate = lastZabbixUpdate
+    }
+
+    func resetWatermark() {
+        lastObjectChangeId = nil
+        lastObjectChangeTime = nil
+        lastFullMirrorAt = nil
+        lastDeltaSummary = nil
     }
 }

--- a/Pulse/NetBox/NetBoxDelta.swift
+++ b/Pulse/NetBox/NetBoxDelta.swift
@@ -1,0 +1,149 @@
+//
+//  NetBoxDelta.swift
+//  Pulse
+//
+//  Copyright © 2025–present Omega Networks Limited.
+//
+//  Pulse
+//  The Platform for Unified Leadership in Smart Environments.
+//
+//  This program is distributed to enable communities to build and maintain their own
+//  digital sovereignty through local control of critical infrastructure data.
+//
+//  By open sourcing Pulse, we create a circular economy where contributors can both build
+//  upon and benefit from the platform, ensuring that value flows back to communities rather
+//  than being extracted by external entities. This aligns with our commitment to intergenerational
+//  prosperity through collaborative stewardship of public infrastructure.
+//
+//  This program is free software: communities can deploy it for sovereignty, academia can
+//  extend it for research, and industry can integrate it for resilience — all under the terms
+//  of the GNU Affero General Public License version 3 as published by the Free Software Foundation.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+/// Changelog kinds Pulse applies. Raw values match NetBox
+/// `changed_object_type`. Order is FK order, not raw time.
+enum NetBoxChangeKind: String, Sendable, CaseIterable, Comparable {
+    case tenantGroup = "tenancy.tenantgroup"
+    case deviceRole = "dcim.devicerole"
+    case deviceType = "dcim.devicetype"
+    case tenant = "tenancy.tenant"
+    case region = "dcim.region"
+    case siteGroup = "dcim.sitegroup"
+    case site = "dcim.site"
+    case rack = "dcim.rack"
+    case device = "dcim.device"
+    case interface = "dcim.interface"
+    case service = "ipam.service"
+    case cable = "dcim.cable"
+
+    private var rank: Int {
+        switch self {
+        case .tenantGroup: return 0
+        case .deviceRole: return 1
+        case .deviceType: return 2
+        case .tenant: return 3
+        case .region: return 4
+        case .siteGroup: return 5
+        case .site: return 6
+        case .rack: return 7
+        case .device: return 8
+        case .interface: return 9
+        case .service: return 10
+        case .cable: return 11
+        }
+    }
+
+    static func < (lhs: NetBoxChangeKind, rhs: NetBoxChangeKind) -> Bool {
+        lhs.rank < rhs.rank
+    }
+
+    init?(objectType: String) {
+        if let exact = NetBoxChangeKind(rawValue: objectType) {
+            self = exact
+            return
+        }
+        switch objectType {
+        case "dcim.device_role", "dcim.devicerole": self = .deviceRole
+        case "dcim.device_type", "dcim.devicetype": self = .deviceType
+        case "tenancy.tenant_group", "tenancy.tenantgroup": self = .tenantGroup
+        case "dcim.site_group", "dcim.sitegroup": self = .siteGroup
+        default: return nil
+        }
+    }
+
+    var retrievePath: String {
+        switch self {
+        case .tenantGroup: return "/api/tenancy/tenant-groups/"
+        case .deviceRole: return "/api/dcim/device-roles/"
+        case .deviceType: return "/api/dcim/device-types/"
+        case .tenant: return "/api/tenancy/tenants/"
+        case .region: return "/api/dcim/regions/"
+        case .siteGroup: return "/api/dcim/site-groups/"
+        case .site: return "/api/dcim/sites/"
+        case .rack: return "/api/dcim/racks/"
+        case .device: return "/api/dcim/devices/"
+        case .interface: return "/api/dcim/interfaces/"
+        case .service: return "/api/ipam/services/"
+        case .cable: return "/api/dcim/cables/"
+        }
+    }
+}
+
+struct NetBoxDeltaItem: Sendable, Equatable {
+    var kind: NetBoxChangeKind
+    var objectID: Int64
+    var action: String
+    var changeID: Int64
+    var time: Date?
+}
+
+enum NetBoxDelta {
+    /// Last action per (type, id), then FK order. `request_id` is ignored
+    /// for sequencing — kind rank is what keeps parents before children.
+    static func coalesce(_ changes: [NetBoxRecord.ObjectChange]) -> (
+        items: [NetBoxDeltaItem],
+        skippedUnknown: Int,
+        highWater: (id: Int64, time: Date?)?
+    ) {
+        var latest: [String: NetBoxRecord.ObjectChange] = [:]
+        var skippedUnknown = 0
+        var highID: Int64 = 0
+        var highTime: Date?
+        for change in changes {
+            if change.id > highID {
+                highID = change.id
+                highTime = change.time
+            }
+            guard NetBoxChangeKind(objectType: change.changedObjectType) != nil else {
+                skippedUnknown += 1
+                continue
+            }
+            let key = "\(change.changedObjectType):\(change.changedObjectID)"
+            if let existing = latest[key], existing.id > change.id { continue }
+            latest[key] = change
+        }
+        let items = latest.values.compactMap { change -> NetBoxDeltaItem? in
+            guard let kind = NetBoxChangeKind(objectType: change.changedObjectType) else {
+                return nil
+            }
+            return NetBoxDeltaItem(
+                kind: kind,
+                objectID: change.changedObjectID,
+                action: change.action,
+                changeID: change.id,
+                time: change.time
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.kind != rhs.kind { return lhs.kind < rhs.kind }
+            return lhs.objectID < rhs.objectID
+        }
+        let water: (id: Int64, time: Date?)? = highID > 0 ? (highID, highTime) : nil
+        return (items, skippedUnknown, water)
+    }
+}

--- a/Pulse/NetBox/NetBoxListDecoder.swift
+++ b/Pulse/NetBox/NetBoxListDecoder.swift
@@ -78,6 +78,14 @@ enum NetBoxListDecoder {
         )
     }
 
+    static func decodeObject<Element: Decodable>(
+        _ type: Element.Type,
+        from data: Data,
+        decoder: JSONDecoder = makeDecoder()
+    ) throws -> Element {
+        try decoder.decode(Element.self, from: data)
+    }
+
     static func describe(_ error: Error) -> String {
         switch error {
         case let DecodingError.keyNotFound(key, context):

--- a/Pulse/NetBox/NetBoxMapping.swift
+++ b/Pulse/NetBox/NetBoxMapping.swift
@@ -131,6 +131,7 @@ enum NetBoxRecord {
         var roleID: Int64
         var typeID: Int64
         var rackID: Int64?
+        var manufacturerID: Int64?
     }
 
     struct Service: Sendable, Equatable {
@@ -175,6 +176,20 @@ enum NetBoxRecord {
         var bridgeName: String?
         var parentID: Int64?
         var parentName: String?
+    }
+
+    struct ObjectChange: Sendable, Equatable {
+        var id: Int64
+        var time: Date?
+        var action: String
+        var changedObjectType: String
+        var changedObjectID: Int64
+        var requestID: String?
+    }
+
+    struct Cable: Sendable, Equatable {
+        var id: Int64
+        var interfaceIDs: [Int64]
     }
 
     struct StaticDevice: Sendable, Equatable {
@@ -465,7 +480,15 @@ extension NetBoxRecord.Device: Decodable {
         roleID = role
         typeID = type
         rackID = try NetBoxIngest.nestedID(container, .rack)
+        if container.contains(.deviceType), try container.decodeNil(forKey: .deviceType) == false {
+            let typeContainer = try container.nestedContainer(keyedBy: ManufacturerKey.self, forKey: .deviceType)
+            manufacturerID = try NetBoxIngest.nestedID(typeContainer, .manufacturer)
+        } else {
+            manufacturerID = nil
+        }
     }
+
+    private enum ManufacturerKey: String, CodingKey { case manufacturer }
 }
 
 extension NetBoxRecord.Service: Decodable {
@@ -656,6 +679,137 @@ extension NetBoxRecord.DeviceBay: Decodable {
     }
 }
 
+extension NetBoxRecord.ObjectChange: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case id, time, action
+        case changedObjectType = "changed_object_type"
+        case changedObjectID = "changed_object_id"
+        case requestID = "request_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        time = try container.decodeIfPresent(Date.self, forKey: .time)
+        action = try NetBoxIngest.choiceValue(container, .action) ?? ""
+        changedObjectType = try container.decode(String.self, forKey: .changedObjectType)
+        changedObjectID = try container.decode(Int64.self, forKey: .changedObjectID)
+        requestID = try container.decodeIfPresent(String.self, forKey: .requestID)
+    }
+}
+
+extension NetBoxRecord.Cable: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case aTerminations = "a_terminations"
+        case bTerminations = "b_terminations"
+    }
+
+    enum TerminationKey: String, CodingKey {
+        case objectType = "object_type"
+        case objectID = "object_id"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        var ids: [Int64] = []
+        ids.append(contentsOf: Self.interfaceIDs(container, .aTerminations))
+        ids.append(contentsOf: Self.interfaceIDs(container, .bTerminations))
+        interfaceIDs = ids
+    }
+
+    private static func interfaceIDs(
+        _ container: KeyedDecodingContainer<CodingKeys>,
+        _ key: CodingKeys
+    ) -> [Int64] {
+        guard let rows = try? container.decode([Failable<Termination>].self, forKey: key) else {
+            return []
+        }
+        return rows.compactMap { row in
+            guard let value = row.value, value.objectType == "dcim.interface" else { return nil }
+            return value.objectID
+        }
+    }
+
+    private struct Termination: Decodable {
+        var objectType: String
+        var objectID: Int64
+        enum CodingKeys: String, CodingKey {
+            case objectType = "object_type"
+            case objectID = "object_id"
+        }
+    }
+
+    private struct Failable<T: Decodable>: Decodable {
+        var value: T?
+        init(from decoder: Decoder) throws {
+            value = try? T(from: decoder)
+        }
+    }
+}
+
+extension NetBoxRecord.TenantGroup: Decodable {
+    enum CodingKeys: String, CodingKey { case id, name, created, last_updated }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        created = try container.decodeIfPresent(Date.self, forKey: .created)
+        lastUpdated = try container.decodeIfPresent(Date.self, forKey: .last_updated)
+    }
+}
+
+extension NetBoxRecord.DeviceRole: Decodable {
+    enum CodingKeys: String, CodingKey { case id, name, created, last_updated, color }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        created = try container.decodeIfPresent(Date.self, forKey: .created)
+        lastUpdated = try container.decodeIfPresent(Date.self, forKey: .last_updated)
+        colour = try container.decodeIfPresent(String.self, forKey: .color)
+    }
+}
+
+extension NetBoxRecord.DeviceType: Decodable {
+    enum CodingKeys: String, CodingKey { case id, model, created, last_updated, manufacturer, u_height }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        model = try container.decodeIfPresent(String.self, forKey: .model) ?? ""
+        created = try container.decodeIfPresent(Date.self, forKey: .created)
+        lastUpdated = try container.decodeIfPresent(Date.self, forKey: .last_updated)
+        uHeight = try container.decodeIfPresent(Double.self, forKey: .u_height).map(Float.init)
+        manufacturerID = try NetBoxIngest.nestedID(container, .manufacturer) ?? 0
+    }
+}
+
+extension NetBoxRecord.Region: Decodable {
+    enum CodingKeys: String, CodingKey { case id, name, created, last_updated, site_count, parent }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        created = try container.decodeIfPresent(Date.self, forKey: .created)
+        lastUpdated = try container.decodeIfPresent(Date.self, forKey: .last_updated)
+        siteCount = try container.decodeIfPresent(Int64.self, forKey: .site_count) ?? 0
+        parentID = try NetBoxIngest.nestedID(container, .parent)
+    }
+}
+
+extension NetBoxRecord.SiteGroup: Decodable {
+    enum CodingKeys: String, CodingKey { case id, name, created, last_updated, parent }
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int64.self, forKey: .id)
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        created = try container.decodeIfPresent(Date.self, forKey: .created)
+        lastUpdated = try container.decodeIfPresent(Date.self, forKey: .last_updated)
+        parentID = try NetBoxIngest.nestedID(container, .parent)
+    }
+}
+
 enum NetBoxMapping {
     static func tenantGroup(_ value: Components.Schemas.TenantGroup) -> NetBoxRecord.TenantGroup {
         NetBoxRecord.TenantGroup(
@@ -777,7 +931,8 @@ enum NetBoxMapping {
             siteID: Int64(value.site.id),
             roleID: Int64(value.role.id),
             typeID: Int64(value.device_type.id),
-            rackID: value.rack.map { Int64($0.value1.id) }
+            rackID: value.rack.map { Int64($0.value1.id) },
+            manufacturerID: Int64(value.device_type.manufacturer.id)
         )
     }
 

--- a/Pulse/NetBox/NetBoxStore.swift
+++ b/Pulse/NetBox/NetBoxStore.swift
@@ -44,6 +44,25 @@ enum NetBoxStore {
         fetchComplete && skipped == 0
     }
 
+    /// Per-id delete for changelog `action=delete`. Missing ids are a no-op.
+    @discardableResult
+    static func deleteIDs<T: PersistentModel & NetBoxIdentified>(
+        _ type: T.Type,
+        ids: [Int64],
+        in context: ModelContext
+    ) throws -> Int {
+        let existing = try fetchByIDs(type, ids: ids, in: context)
+        var deleted = 0
+        for row in existing.values {
+            context.delete(row)
+            deleted += 1
+        }
+        if deleted > 0 {
+            try context.save()
+        }
+        return deleted
+    }
+
     // MARK: - Tenant groups
 
     static func applyTenantGroups(
@@ -680,7 +699,7 @@ extension NetBoxRecord.Device: NetBoxRecordID {}
 extension NetBoxRecord.Service: NetBoxRecordID {}
 extension NetBoxRecord.Interface: NetBoxRecordID {}
 
-private protocol NetBoxIdentified: AnyObject {
+protocol NetBoxIdentified: AnyObject {
     var id: Int64 { get }
 }
 

--- a/Pulse/NetBox/NetBoxSyncEngine.swift
+++ b/Pulse/NetBox/NetBoxSyncEngine.swift
@@ -49,9 +49,29 @@ actor NetBoxSyncEngine {
         self.filter = filter
     }
 
-    /// Tenant groups → roles → types → tenants → regions → site groups →
-    /// sites → racks → devices → services → interfaces. Boot and Settings
-    /// → Sync Data both wait for every stage, including interfaces.
+    /// Weekly safety full mirror. Changelog misses out-of-request-context edits.
+    static let safetyMirrorInterval: TimeInterval = 7 * 24 * 60 * 60
+
+    /// Boot entry: delta when a watermark is usable, otherwise a full mirror.
+    func sync(progress: (@Sendable (Int, String) -> Void)? = nil) async throws {
+        if let inFlight {
+            try await inFlight.value
+            return
+        }
+        let task = Task(priority: .userInitiated) {
+            try await self.performBootSync(progress: progress)
+        }
+        inFlight = task
+        defer { inFlight = nil }
+        do {
+            try await task.value
+        } catch {
+            logger.error("NetBox sync failed: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Settings → Sync Data. Always a full mirror, then a fresh watermark.
     func fullSync(progress: (@Sendable (Int, String) -> Void)? = nil) async throws {
         if let inFlight {
             try await inFlight.value
@@ -59,6 +79,7 @@ actor NetBoxSyncEngine {
         }
         let task = Task(priority: .userInitiated) {
             try await self.performFullSync(progress: progress)
+            try await self.stampFullSuccess()
         }
         inFlight = task
         defer { inFlight = nil }
@@ -88,7 +109,53 @@ actor NetBoxSyncEngine {
             progress?(index, stage.0)
             try await stage.1()
         }
-        try await stampSuccess()
+    }
+
+    private func performBootSync(progress: (@Sendable (Int, String) -> Void)?) async throws {
+        let plan = try await applyOnStore { context in
+            try Self.decideSync(in: context)
+        }
+        switch plan {
+        case .full(let reason):
+            logger.info("NetBox full mirror (\(reason, privacy: .public))")
+            try await performFullSync(progress: progress)
+            try await stampFullSuccess()
+        case .delta(let watermarkID):
+            if await changelogRecordMissing(id: watermarkID) {
+                logger.error("Watermark \(watermarkID) is gone; forcing full mirror")
+                try await performFullSync(progress: progress)
+                try await stampFullSuccess()
+                return
+            }
+            progress?(0, "Applying NetBox changes...")
+            try await performDelta(after: watermarkID)
+        }
+    }
+
+    private enum SyncPlan: Sendable {
+        case full(String)
+        case delta(Int64)
+    }
+
+    private static func decideSync(in context: ModelContext) throws -> SyncPlan {
+        var devicePeek = FetchDescriptor<Device>()
+        devicePeek.fetchLimit = 1
+        var sitePeek = FetchDescriptor<Site>()
+        sitePeek.fetchLimit = 1
+        let devices = try context.fetch(devicePeek)
+        let sites = try context.fetch(sitePeek)
+        let provider = try context.fetch(FetchDescriptor<SyncProvider>()).first
+        if devices.isEmpty && sites.isEmpty {
+            return .full("empty store")
+        }
+        guard let watermark = provider?.lastObjectChangeId else {
+            return .full("no watermark")
+        }
+        if let lastFull = provider?.lastFullMirrorAt,
+           Date().timeIntervalSince(lastFull) >= safetyMirrorInterval {
+            return .full("safety interval")
+        }
+        return .delta(watermark)
     }
 
     // MARK: - Types
@@ -302,19 +369,262 @@ actor NetBoxSyncEngine {
         }.value
     }
 
-    private func stampSuccess() async throws {
-        _ = try await applyOnStore { context in
-            let existing = try context.fetch(FetchDescriptor<SyncProvider>())
-            if let provider = existing.first {
-                provider.lastNetBoxUpdate = Date()
-            } else {
-                context.insert(
-                    SyncProvider(lastNetBoxUpdate: Date(), lastZabbixUpdate: Date.distantPast)
+    // MARK: - Delta
+
+    private func changelogRecordMissing(id: Int64) async -> Bool {
+        do {
+            _ = try await fetcher.get(path: "/api/core/object-changes/\(id)/", query: [])
+            return false
+        } catch NetBoxSyncError.httpStatus(let code, _) where code == 404 {
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func performDelta(after watermarkID: Int64) async throws {
+        let extra = [
+            URLQueryItem(name: "id__gt", value: String(watermarkID)),
+            URLQueryItem(name: "ordering", value: "id"),
+        ]
+        let (rows, skipped) = try await fetchAll(
+            path: "/api/core/object-changes/",
+            extraQuery: extra,
+            as: NetBoxRecord.ObjectChange.self
+        )
+        if skipped > 0 {
+            throw NetBoxSyncError.dataError("Changelog page skipped \(skipped) elements")
+        }
+        let planned = NetBoxDelta.coalesce(rows)
+        for unknown in rows where NetBoxChangeKind(objectType: unknown.changedObjectType) == nil {
+            logger.error(
+                "Skipping unknown changelog type \(unknown.changedObjectType, privacy: .public) id \(unknown.changedObjectID)"
+            )
+        }
+        var touchedDeviceSites = false
+        for item in planned.items {
+            try await applyDeltaItem(item)
+            if item.kind == .device { touchedDeviceSites = true }
+        }
+        if let water = planned.highWater {
+            try await stampDeltaSuccess(
+                id: water.id,
+                time: water.time,
+                summary: "applied \(planned.items.count) objects"
+            )
+        } else {
+            try await stampDeltaSuccess(
+                id: watermarkID,
+                time: nil,
+                summary: "no changes"
+            )
+        }
+        if touchedDeviceSites {
+            await SiteDataService(modelContainer: modelContainer).refreshSeverities()
+        }
+    }
+
+    private func applyDeltaItem(_ item: NetBoxDeltaItem) async throws {
+        if item.action == "delete" {
+            try await deleteObject(kind: item.kind, id: item.objectID)
+            return
+        }
+        if item.kind == .cable {
+            try await refreshCableInterfaces(id: item.objectID)
+            return
+        }
+        do {
+            let data = try await fetcher.get(
+                path: "\(item.kind.retrievePath)\(item.objectID)/",
+                query: []
+            )
+            try await upsertRetrieved(kind: item.kind, data: data)
+        } catch NetBoxSyncError.httpStatus(let code, _) where code == 404 {
+            try await deleteObject(kind: item.kind, id: item.objectID)
+        }
+    }
+
+    private func refreshCableInterfaces(id: Int64) async throws {
+        let data: Data
+        do {
+            data = try await fetcher.get(path: "/api/dcim/cables/\(id)/", query: [])
+        } catch NetBoxSyncError.httpStatus(let code, _) where code == 404 {
+            return
+        }
+        let cable = try NetBoxListDecoder.decodeObject(NetBoxRecord.Cable.self, from: data)
+        for interfaceID in cable.interfaceIDs {
+            try await applyDeltaItem(
+                NetBoxDeltaItem(
+                    kind: .interface,
+                    objectID: interfaceID,
+                    action: "update",
+                    changeID: 0,
+                    time: nil
+                )
+            )
+        }
+    }
+
+    private func upsertRetrieved(kind: NetBoxChangeKind, data: Data) async throws {
+        switch kind {
+        case .tenantGroup:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.TenantGroup.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applyTenantGroups([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .deviceRole:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.DeviceRole.self, from: data)
+            guard filter.includesDeviceRole(id: Int(row.id)) else {
+                try await deleteObject(kind: .deviceRole, id: row.id)
+                return
+            }
+            _ = try await applyOnStore {
+                try NetBoxStore.applyDeviceRoles([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .deviceType:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.DeviceType.self, from: data)
+            guard filter.includesDeviceType(manufacturerID: Int(row.manufacturerID)) else {
+                try await deleteObject(kind: .deviceType, id: row.id)
+                return
+            }
+            _ = try await applyOnStore {
+                try NetBoxStore.applyDeviceTypes([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .tenant:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.Tenant.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applyTenants([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .region:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.Region.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applyRegions([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .siteGroup:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.SiteGroup.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applySiteGroups([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .site:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.Site.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applySites([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .rack:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.Rack.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applyRacks([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .device:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.Device.self, from: data)
+            guard filter.includesDevice(
+                manufacturerID: row.manufacturerID.map(Int.init),
+                roleID: Int(row.roleID)
+            ) else {
+                try await deleteObject(kind: .device, id: row.id)
+                return
+            }
+            _ = try await applyOnStore {
+                try NetBoxStore.applyDevices([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .interface:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.Interface.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applyInterfaces(
+                    [row], fetchComplete: false, skipped: 0, keeping: [], in: $0
                 )
             }
+        case .service:
+            let row = try NetBoxListDecoder.decodeObject(NetBoxRecord.Service.self, from: data)
+            _ = try await applyOnStore {
+                try NetBoxStore.applyServices([row], fetchComplete: false, skipped: 0, in: $0)
+            }
+        case .cable:
+            break
+        }
+    }
+
+    private func deleteObject(kind: NetBoxChangeKind, id: Int64) async throws {
+        _ = try await applyOnStore { context -> Int in
+            switch kind {
+            case .tenantGroup: return try NetBoxStore.deleteIDs(TenantGroup.self, ids: [id], in: context)
+            case .deviceRole: return try NetBoxStore.deleteIDs(DeviceRole.self, ids: [id], in: context)
+            case .deviceType: return try NetBoxStore.deleteIDs(DeviceType.self, ids: [id], in: context)
+            case .tenant: return try NetBoxStore.deleteIDs(Tenant.self, ids: [id], in: context)
+            case .region: return try NetBoxStore.deleteIDs(Region.self, ids: [id], in: context)
+            case .siteGroup: return try NetBoxStore.deleteIDs(SiteGroup.self, ids: [id], in: context)
+            case .site: return try NetBoxStore.deleteIDs(Site.self, ids: [id], in: context)
+            case .rack: return try NetBoxStore.deleteIDs(Rack.self, ids: [id], in: context)
+            case .device: return try NetBoxStore.deleteIDs(Device.self, ids: [id], in: context)
+            case .interface: return try NetBoxStore.deleteIDs(Interface.self, ids: [id], in: context)
+            case .service: return try NetBoxStore.deleteIDs(Service.self, ids: [id], in: context)
+            case .cable: return 0
+            }
+        }
+    }
+
+    private func latestChangelogCursor() async throws -> (id: Int64, time: Date?)? {
+        let (rows, _) = try await NetBoxPageIterator.fetchDecoded(
+            path: "/api/core/object-changes/",
+            extraQuery: [
+                URLQueryItem(name: "ordering", value: "-id"),
+                URLQueryItem(name: "limit", value: "1"),
+            ],
+            as: NetBoxRecord.ObjectChange.self,
+            using: fetcher,
+            maxPages: 1
+        )
+        guard let first = rows.first else { return nil }
+        return (first.id, first.time)
+    }
+
+    private func stampFullSuccess() async throws {
+        let cursor = try? await latestChangelogCursor()
+        _ = try await applyOnStore { context in
+            let now = Date()
+            let provider = try Self.upsertProvider(in: context)
+            provider.lastNetBoxUpdate = now
+            provider.lastFullMirrorAt = now
+            if let cursor {
+                provider.lastObjectChangeId = cursor.id
+                provider.lastObjectChangeTime = cursor.time
+            } else if provider.lastObjectChangeId == nil {
+                provider.lastObjectChangeId = 0
+            }
+            provider.lastDeltaSummary = "full mirror"
             try context.save()
             return true
         }
+    }
+
+    private func stampDeltaSuccess(id: Int64, time: Date?, summary: String) async throws {
+        _ = try await applyOnStore { context in
+            let provider = try Self.upsertProvider(in: context)
+            provider.lastNetBoxUpdate = Date()
+            provider.lastObjectChangeId = id
+            if let time {
+                provider.lastObjectChangeTime = time
+            }
+            provider.lastDeltaSummary = summary
+            try context.save()
+            return true
+        }
+    }
+
+    private static func upsertProvider(in context: ModelContext) throws -> SyncProvider {
+        let existing = try context.fetch(FetchDescriptor<SyncProvider>())
+        if let provider = existing.first {
+            return provider
+        }
+        let created = SyncProvider(lastNetBoxUpdate: Date(), lastZabbixUpdate: Date.distantPast)
+        context.insert(created)
+        return created
+    }
+}
+
+private extension NetBoxSyncError {
+    static func dataError(_ message: String) -> NetBoxSyncError {
+        .httpStatus(code: 0, body: message)
     }
 }
 

--- a/Pulse/PulseApp.swift
+++ b/Pulse/PulseApp.swift
@@ -278,7 +278,7 @@ struct PulseApp: App {
         // NetBoxSyncEngine is the single NetBox owner; boot and Sync Dashboard
         // share it so they cannot race.
         do {
-            try await netBoxSyncEngine.fullSync { step, label in
+            try await netBoxSyncEngine.sync { step, label in
                 Task { @MainActor in
                     initState.updateProgress(step, label)
                 }

--- a/Pulse/SyncDashboardView.swift
+++ b/Pulse/SyncDashboardView.swift
@@ -123,6 +123,10 @@ struct SyncDashboardView: View {
                 LabeledContent("Racks:", value: String(racks.count))
                 LabeledContent("Devices:", value: String(devices.count))
                 LabeledContent("Interfaces:", value: String(interfaces.count))
+                if let provider = syncProvider.first {
+                    LabeledContent("Changelog watermark:", value: watermarkLabel(provider))
+                    LabeledContent("Last delta:", value: provider.lastDeltaSummary ?? "—")
+                }
             }
             .id(contextDidSaveDate)
             HStack {
@@ -157,12 +161,12 @@ struct SyncDashboardView: View {
                 
                 /// Button for fetching data from NetBox
                 ///
-                Button(isMonitoringEnabled ? "Syncing" : "Sync Data") {
+                Button(isMonitoringEnabled ? "Syncing" : "Full Resync") {
                     Task.detached(priority: .background) {
                         await syncData()
                     }
                 }
-                .frame(width: 100)
+                .frame(width: 120)
                 .buttonStyle(.borderedProminent)
                 .disabled(isMonitoringEnabled)
                 .padding(4)
@@ -313,10 +317,25 @@ struct SyncDashboardView: View {
                 print("\(model) data deleted successfully.")
             }
             try context.save()
+            let providers = try context.fetch(FetchDescriptor<SyncProvider>())
+            for provider in providers {
+                provider.resetWatermark()
+            }
+            try context.save()
             print("All data deleted successfully.")
         } catch {
             print("Failed to delete all data: \(error)")
         }
+    }
+
+    private func watermarkLabel(_ provider: SyncProvider) -> String {
+        guard let id = provider.lastObjectChangeId else { return "none" }
+        if let time = provider.lastObjectChangeTime {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .short
+            return "#\(id) (\(formatter.localizedString(for: time, relativeTo: Date())))"
+        }
+        return "#\(id)"
     }
     
     

--- a/PulseTests/Networking/NetBoxDeltaTests.swift
+++ b/PulseTests/Networking/NetBoxDeltaTests.swift
@@ -1,0 +1,263 @@
+//
+//  NetBoxDeltaTests.swift
+//  PulseTests
+//
+//  Copyright © 2025–present Omega Networks Limited.
+//
+//  This program is distributed to enable communities to build and maintain their own
+//  digital sovereignty through local control of critical infrastructure data.
+//
+//  By open sourcing Pulse, we create a circular economy where contributors can both build
+//  upon and benefit from the platform, ensuring that value flows back to communities rather
+//  than being extracted by external entities. This aligns with our commitment to intergenerational
+//  prosperity through collaborative stewardship of public infrastructure.
+//
+//  Under the terms of the GNU Affero General Public License version 3 as published by the
+//  Free Software Foundation, this program is free software: communities can deploy it for
+//  sovereignty, academia can extend it for research, and industry can integrate it for resilience.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import SwiftData
+import XCTest
+@testable import Pulse
+
+final class NetBoxDeltaTests: XCTestCase {
+    func testCoalesceKeepsLatestActionAndOrdersByFK() {
+        let changes = [
+            change(id: 1, type: "dcim.device", object: 10, action: "create"),
+            change(id: 3, type: "dcim.device", object: 10, action: "delete"),
+            change(id: 2, type: "dcim.site", object: 4, action: "update"),
+            change(id: 4, type: "extras.tag", object: 1, action: "update"),
+        ]
+        let planned = NetBoxDelta.coalesce(changes)
+        XCTAssertEqual(planned.skippedUnknown, 1)
+        XCTAssertEqual(planned.items.map(\.kind), [.site, .device])
+        XCTAssertEqual(planned.items.last?.action, "delete")
+        XCTAssertEqual(planned.highWater?.id, 4)
+    }
+
+    func testCableJSONCollectsBothInterfaceTerminations() throws {
+        let json = Data("""
+        {
+          "id": 9,
+          "a_terminations": [{"object_type": "dcim.interface", "object_id": 1}],
+          "b_terminations": [{"object_type": "dcim.interface", "object_id": 2}]
+        }
+        """.utf8)
+        let cable = try NetBoxListDecoder.decodeObject(NetBoxRecord.Cable.self, from: json)
+        XCTAssertEqual(cable.interfaceIDs, [1, 2])
+    }
+
+    func testSyncWithoutWatermarkPerformsFullMirror() async throws {
+        let container = try makeContainer()
+        let fetcher = DeltaFetcher()
+        fetcher.emptySuccess = true
+        let engine = NetBoxSyncEngine(modelContainer: container, fetcher: fetcher)
+        try await engine.sync()
+        XCTAssertTrue(fetcher.paths.contains("/api/dcim/devices/"))
+        let context = ModelContext(container)
+        let provider = try XCTUnwrap(try context.fetch(FetchDescriptor<SyncProvider>()).first)
+        XCTAssertNotNil(provider.lastFullMirrorAt)
+        XCTAssertEqual(provider.lastObjectChangeId, 0)
+    }
+
+    func testWarmWatermarkDoesNotFullPull() async throws {
+        let container = try makeContainer()
+        let seed = ModelContext(container)
+        seed.insert(Site(id: 1))
+        seed.insert(Device(id: 10))
+        let provider = SyncProvider(lastNetBoxUpdate: Date(), lastZabbixUpdate: Date.distantPast)
+        provider.lastObjectChangeId = 50
+        provider.lastFullMirrorAt = Date()
+        seed.insert(provider)
+        try seed.save()
+
+        let fetcher = DeltaFetcher()
+        fetcher.bodies["/api/core/object-changes/50/"] = Data(#"{"id":50,"action":{"value":"update"},"changed_object_type":"dcim.device","changed_object_id":10}"#.utf8)
+        fetcher.bodies["/api/core/object-changes/"] = Data(#"{"count":0,"next":null,"results":[]}"#.utf8)
+        let engine = NetBoxSyncEngine(modelContainer: container, fetcher: fetcher)
+        try await engine.sync()
+        XCTAssertFalse(fetcher.paths.contains("/api/dcim/devices/"))
+        XCTAssertTrue(fetcher.paths.contains("/api/core/object-changes/"))
+        let after = ModelContext(container)
+        XCTAssertEqual(try after.fetch(FetchDescriptor<SyncProvider>()).first?.lastDeltaSummary, "no changes")
+    }
+
+    func testDeleteActionRemovesRowAndMissingWatermarkForcesMirror() async throws {
+        let container = try makeContainer()
+        let seed = ModelContext(container)
+        seed.insert(Site(id: 1))
+        seed.insert(Device(id: 10))
+        try seed.save()
+
+        try NetBoxStore.deleteIDs(Device.self, ids: [10], in: ModelContext(container))
+        XCTAssertTrue(try ModelContext(container).fetch(FetchDescriptor<Device>()).isEmpty)
+
+        let provider = SyncProvider(lastNetBoxUpdate: Date(), lastZabbixUpdate: Date.distantPast)
+        provider.lastObjectChangeId = 99
+        provider.lastFullMirrorAt = Date()
+        let seed2 = ModelContext(container)
+        seed2.insert(Site(id: 1))
+        seed2.insert(provider)
+        try seed2.save()
+
+        let fetcher = DeltaFetcher()
+        fetcher.emptySuccess = true
+        fetcher.fail404.insert("/api/core/object-changes/99/")
+        let engine = NetBoxSyncEngine(modelContainer: container, fetcher: fetcher)
+        try await engine.sync()
+        XCTAssertTrue(fetcher.paths.contains("/api/dcim/devices/"))
+    }
+
+    func testDeltaCreateAppliesRetrievedDevice() async throws {
+        let container = try makeContainer()
+        let seed = ModelContext(container)
+        let site = Site(id: 1)
+        seed.insert(site)
+        seed.insert(Device(id: 1))
+        let provider = SyncProvider(lastNetBoxUpdate: Date(), lastZabbixUpdate: Date.distantPast)
+        provider.lastObjectChangeId = 10
+        provider.lastFullMirrorAt = Date()
+        seed.insert(provider)
+        try seed.save()
+
+        let fetcher = DeltaFetcher()
+        fetcher.bodies["/api/core/object-changes/10/"] = Data(#"{"id":10}"#.utf8)
+        fetcher.bodies["/api/core/object-changes/"] = Data("""
+        {"count":1,"next":null,"results":[
+          {"id":11,"time":"2026-08-13T00:00:00Z",
+           "action":{"value":"create","label":"Created"},
+           "changed_object_type":"dcim.device","changed_object_id":20,
+           "request_id":"r1"}
+        ]}
+        """.utf8)
+        fetcher.bodies["/api/dcim/devices/20/"] = Data("""
+        {"id":20,"name":"edge","site":{"id":1},"role":{"id":2},"device_type":{"id":8}}
+        """.utf8)
+        let engine = NetBoxSyncEngine(modelContainer: container, fetcher: fetcher)
+        try await engine.sync()
+        let devices = try ModelContext(container).fetch(FetchDescriptor<Device>())
+        XCTAssertTrue(devices.contains { $0.id == 20 })
+        XCTAssertEqual(
+            try ModelContext(container).fetch(FetchDescriptor<SyncProvider>()).first?.lastObjectChangeId,
+            11
+        )
+    }
+
+    func testMidDeltaFailureDoesNotAdvanceWatermark() async throws {
+        let container = try makeContainer()
+        let seed = ModelContext(container)
+        seed.insert(Site(id: 1))
+        seed.insert(Device(id: 1))
+        let provider = SyncProvider(lastNetBoxUpdate: Date(), lastZabbixUpdate: Date.distantPast)
+        provider.lastObjectChangeId = 10
+        provider.lastFullMirrorAt = Date()
+        seed.insert(provider)
+        try seed.save()
+
+        let fetcher = DeltaFetcher()
+        fetcher.bodies["/api/core/object-changes/10/"] = Data(#"{"id":10}"#.utf8)
+        fetcher.bodies["/api/core/object-changes/"] = Data("""
+        {"count":1,"next":null,"results":[
+          {"id":12,"action":{"value":"update"},
+           "changed_object_type":"dcim.device","changed_object_id":1}
+        ]}
+        """.utf8)
+        fetcher.fail404.insert("/api/dcim/devices/1/")
+        fetcher.transportOn.insert("/api/dcim/devices/1/")
+        let engine = NetBoxSyncEngine(modelContainer: container, fetcher: fetcher)
+        do {
+            try await engine.sync()
+            XCTFail("expected transport failure")
+        } catch {
+            // expected
+        }
+        XCTAssertEqual(
+            try ModelContext(container).fetch(FetchDescriptor<SyncProvider>()).first?.lastObjectChangeId,
+            10
+        )
+    }
+
+    func testExcludedRoleDeviceBecomesLocalDelete() async throws {
+        let container = try makeContainer()
+        let seed = ModelContext(container)
+        seed.insert(Site(id: 1))
+        seed.insert(Device(id: 30))
+        let provider = SyncProvider(lastNetBoxUpdate: Date(), lastZabbixUpdate: Date.distantPast)
+        provider.lastObjectChangeId = 1
+        provider.lastFullMirrorAt = Date()
+        seed.insert(provider)
+        try seed.save()
+
+        let fetcher = DeltaFetcher()
+        fetcher.bodies["/api/core/object-changes/1/"] = Data(#"{"id":1}"#.utf8)
+        fetcher.bodies["/api/core/object-changes/"] = Data("""
+        {"count":1,"next":null,"results":[
+          {"id":2,"action":{"value":"update"},
+           "changed_object_type":"dcim.device","changed_object_id":30}
+        ]}
+        """.utf8)
+        fetcher.bodies["/api/dcim/devices/30/"] = Data("""
+        {"id":30,"name":"hidden","site":{"id":1},"role":{"id":29},"device_type":{"id":8}}
+        """.utf8)
+        let engine = NetBoxSyncEngine(modelContainer: container, fetcher: fetcher)
+        try await engine.sync()
+        XCTAssertFalse(try ModelContext(container).fetch(FetchDescriptor<Device>()).contains { $0.id == 30 })
+    }
+
+    private func change(
+        id: Int64, type: String, object: Int64, action: String
+    ) -> NetBoxRecord.ObjectChange {
+        NetBoxRecord.ObjectChange(
+            id: id,
+            time: nil,
+            action: action,
+            changedObjectType: type,
+            changedObjectID: object,
+            requestID: "r"
+        )
+    }
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            TenantGroup.self, Tenant.self, Region.self, DeviceRole.self, DeviceType.self,
+            Rack.self, SiteGroup.self, Site.self, Device.self, Interface.self, Service.self,
+            WebHostTrust.self, Event.self, SyncProvider.self, PowerSenseDevice.self,
+            PowerSenseEvent.self, SSHCredential.self, KnownHost.self
+        ])
+        return try ModelContainer(
+            for: schema,
+            configurations: [ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)]
+        )
+    }
+}
+
+private final class DeltaFetcher: NetBoxFetching, @unchecked Sendable {
+    var paths: [String] = []
+    var bodies: [String: Data] = [:]
+    var fail404: Set<String> = []
+    var transportOn: Set<String> = []
+    var emptySuccess = false
+    private let emptyPage = Data(#"{"count":0,"next":null,"results":[]}"#.utf8)
+
+    func get(path: String, query: [URLQueryItem]) async throws -> Data {
+        paths.append(path)
+        if transportOn.contains(path) {
+            throw NetBoxSyncError.transport("killed")
+        }
+        if fail404.contains(path) {
+            throw NetBoxSyncError.httpStatus(code: 404, body: "missing")
+        }
+        if let body = bodies[path] {
+            return body
+        }
+        if emptySuccess {
+            return emptyPage
+        }
+        throw NetBoxSyncError.httpStatus(code: 404, body: path)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Connect to network devices over SSH without leaving Pulse. Credentials are backe
 
 ## Capabilities
 
-- ✅ NetBox integration for infrastructure visualization (generated OpenAPI types; inventory + persisted interfaces; offline topology after one sync)
+- ✅ NetBox integration for infrastructure visualization (generated OpenAPI types; persisted interfaces; changelog incremental sync after the first full mirror)
 - ✅ Zabbix monitoring with real-time status updates
 - ✅ Historical data analysis and pattern recognition
 - ✅ 2D/3D topology visualization

--- a/docs/architecture/0003-netbox-openapi-sync.md
+++ b/docs/architecture/0003-netbox-openapi-sync.md
@@ -30,7 +30,7 @@ The previous read path was `APIRequest` + `NetboxResource` + hand-written `*Prop
 |---|---|
 | **P1 (this ADR)** | Generated GET client, boot + dashboard + on-demand site loads, ingest DTOs, delete gate, Add Site disabled, operator stub |
 | **P2 (this amendment)** | Persisted `Interface` `@Model`, streaming ingest, `InterfaceVO` edges, drop `InterfaceCache` |
-| **P3** | Changelog watermark, delta pass |
+| **P3 (this amendment)** | Changelog watermark, boot delta pass, weekly safety mirror |
 | **P4** | MACD writes, real Add Site, ETag |
 
 ## Structural enforcement
@@ -69,7 +69,7 @@ Delete All includes `Interface`. Map pin colour reads stored severity fields on 
 |---|---|
 | Gate 1 — lab count parity, skip+delete, network kill, Add Site disabled | In progress (lab) |
 | Gate 2 — offline interfaces | Lab 2026-08-13: startup sync, offline site open, edge parity (minus accepted dedupe), Delete All signed off. Owner waived proxy capture, P1-store upgrade, Instruments, headless re-run. Cables deferred. |
-| Gate 3 — changelog converge | Not yet |
+| Gate 3 — changelog converge | Not yet (lab; blocks P3 merge) |
 | Gate 4 — write round-trips | Not yet |
 
 ## Delete All and SwiftData
@@ -99,3 +99,4 @@ Do not “fix” this by deleting Events later in the type list or by hoping `@Q
 - 2026-08-13 — Transport: `NetBoxLiveFetcher` ratified for P1; factory/middleware retained for the generated path; one `NetBoxAuthorization` rule. Store apply hops to user-initiated QoS.
 - 2026-08-13 — P2: persisted `Interface`, streaming ingest, out-of-scope vs skipped, VO edges, cache deleted. Gate 2 still lab.
 - 2026-08-13 — P2 lab: owner signed startup/offline/edges/Delete All. Site-open interface HTTP already removed. Cables into SwiftData deferred.
+- 2026-08-13 — P3: `lastObjectChangeId`/`Time` are NetBox server values, advanced only after a fully applied delta. Boot uses delta when the watermark is present and retained; full mirror on empty store, missing watermark, 404 watermark, or weekly safety. Settings → Full Resync is always a mirror. Unknown `changed_object_type` is skipped. `dcim.cable` re-fetches both interface ends.

--- a/docs/netbox-sync.md
+++ b/docs/netbox-sync.md
@@ -1,6 +1,10 @@
 # NetBox sync (operator)
 
-Pulse mirrors a subset of NetBox into local SwiftData on every launch and when you press **Sync Data** in Settings → Database. Interfaces are a stage of that same full pull (after devices and services). The launch screen stays up until the interface walk finishes. After a failed walk, freshness is not stamped and the next launch retries. Incremental changelog sync (P3) will replace this one-time full interface pull.
+Pulse mirrors a subset of NetBox into local SwiftData. The **first** launch (and any launch with no changelog watermark) does a full pull, including interfaces. After that, boot applies `/api/core/object-changes/` since the last applied change id. Settings → Database → **Full Resync** still does a complete mirror.
+
+A watermark older than NetBox’s retained changelog (default 90 days — `CHANGELOG_RETENTION` must exceed the longest expected offline gap) or a wiped store with a leftover watermark forces a full mirror. A weekly safety mirror covers edits made without request context (shell, migrations).
+
+After a failed delta, the watermark does not move; the next run retries from the same id.
 
 ## Token
 
@@ -25,7 +29,7 @@ Changing these is configuration, not a code edit. A Settings UI comes later.
 
 ## Forced resync
 
-Settings → Database → **Sync Data**. That is a full pull. There is no incremental changelog pass yet (P3).
+Settings → Database → **Full Resync**. That is a complete pull and resets the changelog watermark to the latest object-change id. Ordinary launches apply deltas only.
 
 **Delete All Data** wipes NetBox (and Event) rows on a side context so the open map and event toolbar are not left holding deleted models. If it crashes with `Event.rClock` / “backing data could no longer be found”, rebuild this branch (commit `47684d2` or later). A later change will replace the store file instead of deleting row-by-row.
 


### PR DESCRIPTION
Refs ADR 0003.

P2 is merged (#43). This is P3: after the first full mirror, boot applies `/api/core/object-changes/` instead of pulling every type.

## Behaviour

- Watermark on `SyncProvider`: `lastObjectChangeId` + `lastObjectChangeTime` (NetBox server values). Advanced only after a fully applied batch.
- Boot: watermark usable → delta; else full mirror. Settings → **Full Resync** is always a mirror and refreshes the watermark from the latest changelog id.
- Forced mirror: no watermark, empty store, watermark id 404 (retention gap), weekly safety interval.
- Mid-delta failure: watermark unmoved. Next run retries from the same id.
- Delete / filter-boundary (role 29/30, manufacturer 5) → local per-id delete. `dcim.cable` re-fetches both terminated interfaces. Unknown types logged and skipped.
- Delete All Data resets the watermark so the next boot cannot run a delta against an empty store.
- Dashboard shows watermark age and last delta summary.

## Headless

`NetBoxDeltaTests` plus existing NetBox suites (except the one mapping assertion fixed for `manufacturerID`).

## Gate 3 (lab; blocks merge)

Create/update/delete each synced type in NetBox → next launch converges. Filter-boundary move both ways. Cable connect/disconnect updates both interfaces. Kill network mid-delta → watermark unmoved, retry converges. Retention-gap (delete old changelog / 404 watermark) → full mirror. Warm boot with a fresh watermark should be seconds and should not pull `/api/dcim/devices/` list. Interleaved Zabbix polling: boot sync still finishes before the 120s timer starts.

Cables as their own SwiftData type remain deferred (P2 lab note).